### PR TITLE
PRIAPI-138: list link styles with added space

### DIFF
--- a/src/components/Molecules/List/List.css
+++ b/src/components/Molecules/List/List.css
@@ -26,6 +26,7 @@
 .listLink {
   color: grayLight;
   font-size: 13px;
+  line-height: 2;
   padding-right: 6px;
   text-decoration: none;
 }


### PR DESCRIPTION
## [PRIAPI-138: Footer links need added space on small screens](https://fourkitchens.atlassian.net/browse/PRIAPI-138)

**This PR does the following:**
- Adds a taller line height to increase the space below between footer links when stacked on smaller screens

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start` and verify the above [here](http://localhost:9001/?selectedKind=Pages%2FHome&selectedStory=Default&full=1&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
