### PR TITLE
PRIAPI-145: Correct markup for `&` in foundation logo image attributes.

### DIFF
--- a/src/components/Organisms/Footer/Footer.component.js
+++ b/src/components/Organisms/Footer/Footer.component.js
@@ -32,8 +32,8 @@ const Footer = ({ baseUrl }) => (
         <img
           height="52"
           width="149"
-          alt="Bill &amp;amp; Melinda Gates Foundation"
-          title="Bill &amp;amp; Melinda Gates Foundation"
+          alt="Bill &amp; Melinda Gates Foundation"
+          title="Bill &amp; Melinda Gates Foundation"
           typeof="foaf:Image"
           src={gatesSponsorImg}
         />

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -47,10 +47,10 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
       target="_blank"
     >
       <img
-        alt="Bill &amp; Melinda Gates Foundation"
+        alt="Bill & Melinda Gates Foundation"
         height="52"
         src="test-file-stub"
-        title="Bill &amp; Melinda Gates Foundation"
+        title="Bill & Melinda Gates Foundation"
         typeof="foaf:Image"
         width="149"
       />

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -263,10 +263,10 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
         target="_blank"
       >
         <img
-          alt="Bill &amp; Melinda Gates Foundation"
+          alt="Bill & Melinda Gates Foundation"
           height="52"
           src="test-file-stub"
-          title="Bill &amp; Melinda Gates Foundation"
+          title="Bill & Melinda Gates Foundation"
           typeof="foaf:Image"
           width="149"
         />


### PR DESCRIPTION
## [PRIAPI-145: Footer: Double encoded ampersands in alt and title attributes of <img> for Bill & Melinda Gates Foundation link.](https://fourkitchens.atlassian.net/browse/PRIAPI-145)

**This PR does the following:**
- Correct markup for `&` in foundation logo image attributes.

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Mouse over "Bill & Melinda Gates Foundation" logo in footer and ensure the tooltip reads as `Bill & Melinda Gates Foundation`. Should not see `Bill &amp; Melinda`.
- [ ] Run `yarn test` to see snapshot tests pass for Footer and Home components.
