### PR TITLE
feat(menu): style tweaks for layout, scolling, and icon transitions

### DIFF
--- a/src/components/Molecules/Accordion/Accordion.component.js
+++ b/src/components/Molecules/Accordion/Accordion.component.js
@@ -70,6 +70,7 @@ export default class Accordion extends Component {
                 className={`${styles.iconDown} ${
                   this.state.revealed === true ? styles.iconUp : ''
                 }`}
+                viewBox="-2 -2 28 28"
               />
             </a>
           </h5>

--- a/src/components/Molecules/Accordion/Accordion.css
+++ b/src/components/Molecules/Accordion/Accordion.css
@@ -65,14 +65,11 @@
   fill: currentcolor;
   float: right;
   margin-right: -30px;
-  margin-top: -5px;
   transition: transform 300ms ease-out;
   transform: rotate(-90deg);
 }
 
 .iconUp {
-  margin-right: -26px;
-  margin-top: 0;
   transform: rotate(90deg);
 }
 

--- a/src/components/Molecules/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/components/Molecules/Accordion/__snapshots__/Accordion.test.js.snap
@@ -29,7 +29,7 @@ exports[`<Accordion /> Matches the List snapshot 1`] = `
           fill="currentcolor"
           height={28}
           version={1.1}
-          viewBox="0 0 28 28"
+          viewBox="-2 -2 28 28"
           width={28}
         >
           <path

--- a/src/components/Organisms/Header/Header.css
+++ b/src/components/Organisms/Header/Header.css
@@ -103,16 +103,20 @@ svg.mobileSmallIcon {
 }
 
 .mainMenu {
-  height: 100%;
-  min-height: 100vh;
-  left: 0;
   overflow: hidden;
+  overflow-y: auto;
   position: fixed;
+  left: 0;
   top: 0;
+  max-width: 360px;
+  height: 100vh;
   transform: translateX(-100%);
   transition: 0.3s;
-  max-width: 360px;
   z-index: 100;
+}
+
+.mainMenu::-webkit-scrollbar {
+  display: none;
 }
 
 .mainMenuOpen {

--- a/src/components/Organisms/Header/MainMenu.css
+++ b/src/components/Organisms/Header/MainMenu.css
@@ -12,8 +12,7 @@
 .wrapper {
   background-color: gray;
   flex-flow: column;
-  height: 100%;
-  overflow-y: scroll;
+  min-height: 100vh;
   position: relative;
 }
 
@@ -26,7 +25,7 @@
 
 .header {
   border-top: 3px solid orange;
-  flex: 1 0 183px;
+  flex: 0 0 183px;
   padding: 15px 15px 20px;
   color: grayLighter;
 }

--- a/src/components/Organisms/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Organisms/Header/__snapshots__/Header.test.js.snap
@@ -175,7 +175,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -304,7 +304,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -443,7 +443,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -552,7 +552,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -631,7 +631,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -760,7 +760,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -929,7 +929,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path
@@ -1038,7 +1038,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   fill="currentcolor"
                   height={28}
                   version={1.1}
-                  viewBox="0 0 28 28"
+                  viewBox="-2 -2 28 28"
                   width={28}
                 >
                   <path

--- a/src/components/Organisms/Header/__snapshots__/MainMenu.test.js.snap
+++ b/src/components/Organisms/Header/__snapshots__/MainMenu.test.js.snap
@@ -165,7 +165,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -294,7 +294,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -433,7 +433,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -542,7 +542,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -621,7 +621,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -750,7 +750,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -919,7 +919,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path
@@ -1028,7 +1028,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               fill="currentcolor"
               height={28}
               version={1.1}
-              viewBox="0 0 28 28"
+              viewBox="-2 -2 28 28"
               width={28}
             >
               <path

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -176,7 +176,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -305,7 +305,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -444,7 +444,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -553,7 +553,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -632,7 +632,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -761,7 +761,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -930,7 +930,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path
@@ -1039,7 +1039,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     fill="currentcolor"
                     height={28}
                     version={1.1}
-                    viewBox="0 0 28 28"
+                    viewBox="-2 -2 28 28"
                     width={28}
                   >
                     <path


### PR DESCRIPTION
**This PR does the following:**
- Tweaks CSS for MainMenu component and wrappers to allow scrolling without hiding social icons.
- Adjusts Accordion icon to rotate around its visual center.

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
