### PR TITLE
PRIAPI-144: Publish release to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pri-component-library",
+  "name": "@publicradiointl/pri-component-library",
   "version": "0.0.0-development",
   "description": "Contains a node module that exports PRI's React components.",
   "main": "index.js",
@@ -7,7 +7,6 @@
     "git@github.com:PublicRadioInternational/pri-component-library.git",
   "author": "PRI",
   "license": "UNLICENSED",
-  "private": true,
   "contributors": [
     {
       "name": "Patrick Coffey",
@@ -25,8 +24,9 @@
     "**/*.{js,jsx,json,css}": ["prettier --write", "git add"]
   },
   "release": {
-    "verifyConditions": ["@semantic-release/github"],
-    "publish": ["@semantic-release/github"],
+    "verifyConditions": ["@semantic-release/npm", "@semantic-release/github"],
+    "prepare": ["@semantic-release/npm"],
+    "publish": ["@semantic-release/npm", "@semantic-release/github"],
     "success": ["@semantic-release/github"],
     "fail": ["@semantic-release/github"]
   },
@@ -59,6 +59,7 @@
     "@commitlint/cli": "^6.1.2",
     "@commitlint/config-angular": "^6.1.2",
     "@semantic-release/github": "^4.0.3",
+    "@semantic-release/npm": "^3.2.2",
     "@storybook/addon-actions": "^3.3.15",
     "@storybook/react": "^3.3.14",
     "babel-eslint": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,20 @@
     read-pkg "^3.0.0"
     registry-auth-token "^3.3.1"
 
+"@semantic-release/npm@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@semantic-release/npm/-/npm-3.2.2.tgz#e4cc7e4d09d51099e132cd8bbe5adfae08f1078a"
+  dependencies:
+    "@semantic-release/error" "^2.2.0"
+    aggregate-error "^1.0.0"
+    execa "^0.9.0"
+    fs-extra "^5.0.0"
+    lodash "^4.17.4"
+    nerf-dart "^1.0.0"
+    normalize-url "^2.0.1"
+    read-pkg "^3.0.0"
+    registry-auth-token "^3.3.1"
+
 "@semantic-release/release-notes-generator@^6.0.0":
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.6.tgz#c24c3cf6ad3d44e2453d55e5aaf63e0f091251d8"


### PR DESCRIPTION
## [PRIAPI-144: Setup pri-component-library to publish to NPM.](https://fourkitchens.atlassian.net/browse/PRIAPI-144)

**This PR does the following:**
- Configures package to be belong @publicradiointl scope and makes it public.
- Adds release tasks to publish new version of package to npm.

### To Review:

- [x] Checkout this branch.
- [x] This is run when code is merged to master. not sure how to review. :man_shrugging: 
