### PR TITLE
HOTFIX: Url and title not required in CardItem

### DIFF
--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -13,10 +13,36 @@ import Icon from '../../Atoms/Svg/Icons.component';
 const cx = classNames.bind(styles);
 
 /**
+ * Takes an optional link and title, and returns a title structure.
+ *
+ * @param {string} title - Title string.
+ * @param {string} link - Optional url to which {title} should link.
+ * @param {string} className - Class that should be applied to title wrapper.
+ *
+ * @returns {object|null}
+ *   Depending on whether or not a link, or a title is provided, this method
+ *   will return a title, a linked title.
+ */
+const CardTitle = (title, link = null, className = '') => {
+  // If both a link and a title exist, return a linked title.
+  if (link && title) {
+    return (
+      <a className={className} href={link}>
+        {title}
+      </a>
+    );
+  } else if (title) {
+    // If there is just a title, return just the title.
+    return title;
+  }
+
+  return null;
+};
+
+/**
  * Component that renders a Card Item.
  */
-const CardItem = props => {
-  const { url, title, imgSrc, imgAlt, blurb, large, hasAudio } = props;
+const CardItem = ({ url, title, imgSrc, imgAlt, blurb, large, hasAudio }) => {
   const largeClasses = element =>
     cx({
       [element]: true,
@@ -28,12 +54,12 @@ const CardItem = props => {
       typeof="sioc:Item foaf:Document"
     >
       <div className={largeClasses('titleWrap')}>
-        <h2 className={`${!large && styles.title}`}>
-          <a className={styles.link} href={url}>
-            {title}
-          </a>
-        </h2>
-        <span property="dc:title" content={title} />
+        {title && (
+          <h2 className={`${!large && styles.title}`}>
+            {CardTitle(title, url, styles.link)}
+          </h2>
+        )}
+        {title && <span property="dc:title" content={title} />}
         <span property="sioc:num_replies" content="0" datatype="xsd:integer" />
       </div>
       <figure className={largeClasses('image')}>
@@ -59,8 +85,8 @@ const CardItem = props => {
 };
 
 CardItem.propTypes = {
-  url: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  title: PropTypes.string,
   imgSrc: PropTypes.string,
   imgAlt: PropTypes.string,
   blurb: PropTypes.string,
@@ -72,6 +98,8 @@ CardItem.defaultProps = {
   imgSrc: null,
   imgAlt: null,
   blurb: null,
+  url: null,
+  title: null,
   large: false,
   hasAudio: false
 };

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -89,7 +89,7 @@ CardItem.propTypes = {
   title: PropTypes.string,
   imgSrc: PropTypes.string,
   imgAlt: PropTypes.string,
-  blurb: PropTypes.string,
+  blurb: PropTypes.node,
   large: PropTypes.bool,
   hasAudio: PropTypes.bool
 };

--- a/src/components/Molecules/CardItem/CardItem.test.js
+++ b/src/components/Molecules/CardItem/CardItem.test.js
@@ -11,7 +11,15 @@ import CardItem from './CardItem.component';
 describe('<CardItem />', () => {
   it('Matches the Card Item Default snapshot', () => {
     const component = renderer
-      .create(<CardItem url="/" title="Test Title" />)
+      .create(
+        <CardItem
+          url="/"
+          title="Test Title"
+          imgSrc="http://placehold.it/1920x1080.png"
+          imgAlt="Placeholder Image"
+          blurb="Test Teaser"
+        />
+      )
       .toJSON();
     expect(component).toMatchSnapshot();
   });
@@ -20,6 +28,11 @@ describe('<CardItem />', () => {
     const component = renderer
       .create(<CardItem url="/" title="Test Title" large />)
       .toJSON();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('Matches the Card Item No Link or Title snapshot', () => {
+    const component = renderer.create(<CardItem large />).toJSON();
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -35,16 +35,18 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
       href="/"
     >
       <img
-        alt={null}
+        alt="Placeholder Image"
         className="img"
-        src={null}
+        src="http://placehold.it/1920x1080.png"
         typeof="foaf:Image"
       />
     </a>
   </figure>
   <p
     className="blurb"
-  />
+  >
+    Test Teaser
+  </p>
 </article>
 `;
 
@@ -81,6 +83,40 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
   >
     <a
       href="/"
+    >
+      <img
+        alt={null}
+        className="img imgLg"
+        src={null}
+        typeof="foaf:Image"
+      />
+    </a>
+  </figure>
+  <p
+    className="blurb blurbLg"
+  />
+</article>
+`;
+
+exports[`<CardItem /> Matches the Card Item No Link or Title snapshot 1`] = `
+<article
+  className="cardItem cardItemLg"
+  typeof="sioc:Item foaf:Document"
+>
+  <div
+    className="titleWrap titleWrapLg"
+  >
+    <span
+      content="0"
+      datatype="xsd:integer"
+      property="sioc:num_replies"
+    />
+  </div>
+  <figure
+    className="image imageLg"
+  >
+    <a
+      href={null}
     >
       <img
         alt={null}

--- a/src/components/Organisms/CardList/CardList.component.js
+++ b/src/components/Organisms/CardList/CardList.component.js
@@ -16,7 +16,9 @@ const CardList = ({ category, children, url, src, categoryDescription }) => (
   <Section className={`${styles.list} ${styles[category]}`}>
     <header className={styles.header}>
       <a href={url} className={styles.logoLink}>
-        <img src={src} alt={categoryDescription} className={styles.logo} />
+        {src && (
+          <img src={src} alt={categoryDescription} className={styles.logo} />
+        )}
         {categoryDescription}
       </a>
     </header>

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -58,7 +58,6 @@ storiesOf('Organisms/CardList', module)
       />
       <CardItem
         title="Egyptian singer faces the prospect of prison over a joke about the Nile"
-        url="https://interactive-dev.pri.org/stories/2017-07-24/clearing-mines-and-explosives-mosul"
         imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
         imgAlt="Alt Text"
         blurb="An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'"


### PR DESCRIPTION
**This PR does the following:**
- Adjusts the CardItem component such that it does not require a link or title (requirements for freeforms).
- Improves tests for CardItem.
- Adds ability for `blurb` property to contain any valid JSX node.
- Adjusts the CardList component so it doesn't render images if they don't exist.

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Navigate to the [CardItem](http://localhost:9001/?selectedKind=Organisms%2FCardList&selectedStory=Card%20List&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) component and note it still renders as you might expect. Note that the last CardItem has an unlinked title.
