### PR TITLE
HOTFIX: Update card list header colors 

### DIFF
--- a/src/components/Organisms/CardList/CardList.css
+++ b/src/components/Organisms/CardList/CardList.css
@@ -14,14 +14,12 @@
   word-wrap: break-word;
 }
 
-.boston-calling,
-.world,
-.world-words {
-  border-top-color: world;
-}
-
 .america-abroad {
   border-top-color: americaAbroad;
+}
+
+.boston-calling {
+  border-top-color: bostonCalling;
 }
 
 .globalpost {
@@ -32,7 +30,7 @@
   border-top-color: liveWire;
 }
 
-.living-earth {
+.living-on-earth {
   border-top-color: livingEarth;
 }
 
@@ -44,7 +42,11 @@
   border-top-color: playdate;
 }
 
-.science-happiness {
+.pris-the-world {
+  border-top-color: world;
+}
+
+.science-of-happiness {
   border-top-color: scienceHappiness;
 }
 
@@ -52,16 +54,19 @@
   border-top-color: sciFri;
 }
 
-.studio-360,
-.studio {
+.studio-360 {
   border-top-color: studio;
 }
 
-.takeaway {
+.the-takeaway {
   border-top-color: takeaway;
 }
 
-.things-go-boom {
+.the-world-in-words {
+  border-top-color: worldWords;
+}
+
+.things-that-go-boom {
   border-top-color: thingsBoom;
 }
 
@@ -69,8 +74,7 @@
   border-top-color: undiscovered;
 }
 
-.across-womens-lives,
-.awl {
+.across-womens-lives {
   border-top-color: acrossWomensLives;
 }
 

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -21,7 +21,7 @@ storiesOf('Organisms/CardList', module)
   .add('Card List', () => (
     <CardList
       src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
-      category="world"
+      category="pris-the-world"
       url="#"
       categoryDescription="PRIs The World"
     >


### PR DESCRIPTION
**This PR does the following:**
- Updates card list header colors to match the pattern that Patrick set up (pris-the-world)

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Navigate to [here](http://localhost:9001/?selectedKind=Organisms%2FCardList&selectedStory=Card%20List&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) and ensure the card list top border is blue
- [ ] On line 24 of organisms.story.js, change the Category to `the-takeaway` and confirm the top border is red.