### PR TITLE
HOTFIX: Freeform CardItem styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "classnames": "^2.2.5",
     "downshift": "^1.30.0",
+    "html-react-parser": "^0.4.3",
     "postcss-mixins": "^6.2.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -16,15 +16,15 @@ const cx = classNames.bind(styles);
  * Takes an optional link and title, and returns a title structure.
  *
  * @param {node} item - Renderable node.
- * @param {string} link - Optional url to which {title} should link.
- * @param {string} className - Class that should be applied to title wrapper.
+ * @param {string} link - Optional url to which {item} should link.
+ * @param {string} className - Class that should be applied to item wrapper.
  *
  * @returns {object|null}
  *   If a link path is provided, this method will return item wrapped in a link
  *   tag. If a link is not provided, it'll return the item carte blanc.
  */
 const linkedItem = (item, link = null, className = '') => {
-  // If both a link and a title exist, return a linked title.
+  // If both a link and an item exist, return the item wrapped by an anchor tag.
   if (link && item) {
     return (
       <a className={className} href={link}>

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -15,25 +15,25 @@ const cx = classNames.bind(styles);
 /**
  * Takes an optional link and title, and returns a title structure.
  *
- * @param {string} title - Title string.
+ * @param {node} item - Renderable node.
  * @param {string} link - Optional url to which {title} should link.
  * @param {string} className - Class that should be applied to title wrapper.
  *
  * @returns {object|null}
- *   Depending on whether or not a link, or a title is provided, this method
- *   will return a title, a linked title.
+ *   If a link path is provided, this method will return item wrapped in a link
+ *   tag. If a link is not provided, it'll return the item carte blanc.
  */
-const CardTitle = (title, link = null, className = '') => {
+const linkedItem = (item, link = null, className = '') => {
   // If both a link and a title exist, return a linked title.
-  if (link && title) {
+  if (link && item) {
     return (
       <a className={className} href={link}>
-        {title}
+        {item}
       </a>
     );
-  } else if (title) {
-    // If there is just a title, return just the title.
-    return title;
+  } else if (item) {
+    // If there is just an, return just the item.
+    return item;
   }
 
   return null;
@@ -42,12 +42,27 @@ const CardTitle = (title, link = null, className = '') => {
 /**
  * Component that renders a Card Item.
  */
-const CardItem = ({ url, title, imgSrc, imgAlt, blurb, large, hasAudio }) => {
+const CardItem = ({
+  url,
+  title,
+  imgSrc,
+  imgAlt,
+  blurb,
+  large,
+  hasAudio,
+  freeform
+}) => {
   const largeClasses = element =>
     cx({
       [element]: true,
       [`${element}Lg`]: large
     });
+
+  const freeformClasses = element =>
+    cx({
+      [element]: freeform
+    });
+
   return (
     <article
       className={largeClasses('cardItem')}
@@ -55,23 +70,34 @@ const CardItem = ({ url, title, imgSrc, imgAlt, blurb, large, hasAudio }) => {
     >
       <div className={largeClasses('titleWrap')}>
         {title && (
-          <h2 className={`${!large && styles.title}`}>
-            {CardTitle(title, url, styles.link)}
+          <h2
+            className={`${!large && styles.title} ${freeformClasses(
+              'freeformTitle'
+            )}`}
+          >
+            {linkedItem(
+              title,
+              url,
+              `${styles.link} ${freeformClasses('freeformLink')}`
+            )}
           </h2>
         )}
         {title && <span property="dc:title" content={title} />}
         <span property="sioc:num_replies" content="0" datatype="xsd:integer" />
       </div>
-      <figure className={largeClasses('image')}>
-        <a href={url}>
-          <img
-            typeof="foaf:Image"
-            src={imgSrc}
-            alt={imgAlt}
-            className={largeClasses('img')}
-          />
-        </a>
-      </figure>
+      {imgSrc && (
+        <figure className={largeClasses('image')}>
+          {linkedItem(
+            <img
+              typeof="foaf:Image"
+              src={imgSrc}
+              alt={imgAlt}
+              className={largeClasses('img')}
+            />,
+            url
+          )}
+        </figure>
+      )}
       <p className={largeClasses('blurb')}>
         {blurb}
         {hasAudio && (
@@ -91,7 +117,8 @@ CardItem.propTypes = {
   imgAlt: PropTypes.string,
   blurb: PropTypes.node,
   large: PropTypes.bool,
-  hasAudio: PropTypes.bool
+  hasAudio: PropTypes.bool,
+  freeform: PropTypes.bool
 };
 
 CardItem.defaultProps = {
@@ -101,7 +128,8 @@ CardItem.defaultProps = {
   url: null,
   title: null,
   large: false,
-  hasAudio: false
+  hasAudio: false,
+  freeform: false
 };
 
 export default CardItem;

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -1,6 +1,6 @@
 /* import colors... */
 @value colors: "../../00_global/colors.css";
-@value grayLighter, gray, orange from colors;
+@value grayLighter, grayDark, blue, gray, orange from colors;
 
 /* import breakpoints */
 @value min as bp-min from "../../00_global/breakpoints.css";
@@ -31,6 +31,18 @@
 
 .title {
   font-size: 1.5rem;
+}
+
+.freeformTitle {
+  font-size: 1em;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: grayDark;
+}
+
+.freeformLink {
+  color: blue;
+  text-decoration: none;
 }
 
 .link {

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -45,6 +45,7 @@
   text-decoration: none;
 }
 
+.blurb h2 a,
 .link {
   color: gray;
   text-decoration: none;
@@ -88,6 +89,18 @@
 
 .blurbLg {
   padding: 0 1rem;
+}
+
+.blurb a {
+  text-decoration: none;
+}
+
+.blurb a:hover {
+  color: orange;
+}
+
+.blurb p {
+  margin-top: 1rem;
 }
 
 .iconLink {

--- a/src/components/Molecules/CardItem/CardItem.test.js
+++ b/src/components/Molecules/CardItem/CardItem.test.js
@@ -31,8 +31,16 @@ describe('<CardItem />', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('Matches the Card Item No Link or Title snapshot', () => {
-    const component = renderer.create(<CardItem large />).toJSON();
+  it('Matches the Card Item No Link  snapshot', () => {
+    const component = renderer
+      .create(
+        <CardItem
+          title="Test Title"
+          imgSrc="http://placehold.it/1920x1080.png"
+          freeform
+        />
+      )
+      .toJSON();
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -9,10 +9,10 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
     className="titleWrap"
   >
     <h2
-      className="title"
+      className="title "
     >
       <a
-        className="link"
+        className="link "
         href="/"
       >
         Test Title
@@ -32,6 +32,7 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
     className="image"
   >
     <a
+      className=""
       href="/"
     >
       <img
@@ -59,10 +60,10 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
     className="titleWrap titleWrapLg"
   >
     <h2
-      className="false"
+      className="false "
     >
       <a
-        className="link"
+        className="link "
         href="/"
       >
         Test Title
@@ -78,34 +79,29 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
       property="sioc:num_replies"
     />
   </div>
-  <figure
-    className="image imageLg"
-  >
-    <a
-      href="/"
-    >
-      <img
-        alt={null}
-        className="img imgLg"
-        src={null}
-        typeof="foaf:Image"
-      />
-    </a>
-  </figure>
   <p
     className="blurb blurbLg"
   />
 </article>
 `;
 
-exports[`<CardItem /> Matches the Card Item No Link or Title snapshot 1`] = `
+exports[`<CardItem /> Matches the Card Item No Link  snapshot 1`] = `
 <article
-  className="cardItem cardItemLg"
+  className="cardItem"
   typeof="sioc:Item foaf:Document"
 >
   <div
-    className="titleWrap titleWrapLg"
+    className="titleWrap"
   >
+    <h2
+      className="title freeformTitle"
+    >
+      Test Title
+    </h2>
+    <span
+      content="Test Title"
+      property="dc:title"
+    />
     <span
       content="0"
       datatype="xsd:integer"
@@ -113,21 +109,17 @@ exports[`<CardItem /> Matches the Card Item No Link or Title snapshot 1`] = `
     />
   </div>
   <figure
-    className="image imageLg"
+    className="image"
   >
-    <a
-      href={null}
-    >
-      <img
-        alt={null}
-        className="img imgLg"
-        src={null}
-        typeof="foaf:Image"
-      />
-    </a>
+    <img
+      alt={null}
+      className="img"
+      src="http://placehold.it/1920x1080.png"
+      typeof="foaf:Image"
+    />
   </figure>
   <p
-    className="blurb blurbLg"
+    className="blurb"
   />
 </article>
 `;

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -99,6 +99,17 @@ storiesOf('Molecules/CardItem', module)
     />
   ));
 
+storiesOf('Molecules/CardItem', module)
+  .addDecorator(checkA11y)
+  .add('Freeform', () => (
+    <CardItem
+      freeform
+      title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+      url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+      blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+    />
+  ));
+
 /**
  * Add storybook definition for Hero.
  */

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import Parser from 'html-react-parser';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from '@storybook/addon-a11y';
 import { action } from '@storybook/addon-actions';
@@ -106,7 +107,9 @@ storiesOf('Molecules/CardItem', module)
       freeform
       title="50 years on, India is celebrating the Beatles' infamous trip to the country"
       url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-      blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+      blurb={Parser(
+        '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
+      )}
     />
   ));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,6 +902,10 @@ atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
+atob@~1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+
 autoprefixer@^6.3.1:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
@@ -2838,6 +2842,15 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+css@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.1.tgz#73a4c81de85db664d4ee674f7d47085e3b2d55dc"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.3.0"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -3150,6 +3163,12 @@ domexception@^1.0.0:
 domhandler@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
+  dependencies:
+    domelementtype "1"
+
+domhandler@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
   dependencies:
     domelementtype "1"
 
@@ -3850,7 +3869,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@*, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -4499,6 +4518,13 @@ html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
+html-dom-parser@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-0.1.3.tgz#fe22aa84206a46484069138849f29b154a5ee884"
+  dependencies:
+    domhandler "2.3.0"
+    htmlparser2 "3.9.1"
+
 html-element-attributes@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.0.tgz#f06ebdfce22de979db82020265cac541fb17d4fc"
@@ -4536,6 +4562,14 @@ html-minifier@^3.2.3, html-minifier@^3.5.8:
     relateurl "0.2.x"
     uglify-js "3.3.x"
 
+html-react-parser@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-0.4.3.tgz#c1e4c3669ebad8ae8fceea0c4bf8ab6377fa25e7"
+  dependencies:
+    html-dom-parser "0.1.3"
+    react-dom-core "0.0.2"
+    style-to-object "0.2.0"
+
 html-tag-names@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.2.tgz#f65168964c5a9c82675efda882875dcb2a875c22"
@@ -4550,6 +4584,17 @@ html-webpack-plugin@^2.30.1:
     lodash "^4.17.3"
     pretty-error "^2.0.2"
     toposort "^1.0.0"
+
+htmlparser2@3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.1.tgz#621b7a58bc9acd003f7af0a2c9a00aa67c8505d2"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -6453,7 +6498,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@*, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -7407,6 +7452,14 @@ react-docgen@^2.20.0:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
+react-dom-core@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom-core/-/react-dom-core-0.0.2.tgz#0a6de5bb4374f86b22273391763069a1b00ac470"
+  optionalDependencies:
+    fbjs "*"
+    object-assign "*"
+    react "*"
+
 react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
@@ -7507,6 +7560,15 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
+
+react@*:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react@^16.2.0:
   version "16.2.0"
@@ -7879,7 +7941,7 @@ resolve-global@^0.1.0:
   dependencies:
     global-dirs "^0.1.0"
 
-resolve-url@^0.2.1:
+resolve-url@^0.2.1, resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
@@ -8237,6 +8299,15 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map-resolve@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
+  dependencies:
+    atob "~1.1.0"
+    resolve-url "~0.2.1"
+    source-map-url "~0.3.0"
+    urix "~0.1.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
@@ -8263,9 +8334,19 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
+source-map-url@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
+
 source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -8535,6 +8616,12 @@ style-loader@^0.19.1:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
+
+style-to-object@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.2.0.tgz#2a5a4fa1fca9bbdb5b07e1668231af6c3a54c6dd"
+  dependencies:
+    css "2.2.1"
 
 sugarss@^1.0.0:
   version "1.0.1"
@@ -8910,7 +8997,7 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-urix@^0.1.0:
+urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 


### PR DESCRIPTION
**This PR does the following:**
- Adds styling for the freeform CardItems.
- Adjusts the CardItem component so that it doesn't render images if they aren't provided.
- Adjusts the CardItem component so images aren't linked if a link isn't provided.

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Navigate to the [freeform CardItem](http://localhost:9001/?selectedKind=Molecules%2FCardItem&selectedStory=Freeform&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
- [ ] Note that freeform styles are applied.
