### PR TITLE
HOTFIX: Freeform blurb is div and has no margin

### DIFF
--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -13,30 +13,50 @@ import Icon from '../../Atoms/Svg/Icons.component';
 const cx = classNames.bind(styles);
 
 /**
- * Takes an optional link and title, and returns a title structure.
- *
- * @param {node} item - Renderable node.
- * @param {string} link - Optional url to which {item} should link.
- * @param {string} className - Class that should be applied to item wrapper.
- *
- * @returns {object|null}
- *   If a link path is provided, this method will return item wrapped in a link
- *   tag. If a link is not provided, it'll return the item carte blanc.
+ * Renders it's children, linked to a given url.
  */
-const linkedItem = (item, link = null, className = '') => {
-  // If both a link and an item exist, return the item wrapped by an anchor tag.
-  if (link && item) {
+const LinkedItem = ({ url, children, className }) => {
+  if (url) {
     return (
-      <a className={className} href={link}>
-        {item}
+      <a className={className} href={url}>
+        {children}
       </a>
     );
-  } else if (item) {
-    // If there is just an, return just the item.
-    return item;
   }
 
-  return null;
+  return children || null;
+};
+
+LinkedItem.propTypes = {
+  url: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired
+};
+
+LinkedItem.defaultProps = {
+  url: null,
+  className: null
+};
+
+/**
+ * Renders blurb content in a paragraph or a div, if freeform is true.
+ */
+const BlurbContent = ({ freeform, children, className }) => {
+  if (freeform) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return <p className={className}>{children}</p>;
+};
+
+BlurbContent.propTypes = {
+  freeform: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
+};
+
+BlurbContent.defaultProps = {
+  className: null
 };
 
 /**
@@ -75,11 +95,12 @@ const CardItem = ({
               'freeformTitle'
             )}`}
           >
-            {linkedItem(
-              title,
-              url,
-              `${styles.link} ${freeformClasses('freeformLink')}`
-            )}
+            <LinkedItem
+              url={url}
+              className={`${styles.link} ${freeformClasses('freeformLink')}`}
+            >
+              {title},
+            </LinkedItem>
           </h2>
         )}
         {title && <span property="dc:title" content={title} />}
@@ -87,25 +108,24 @@ const CardItem = ({
       </div>
       {imgSrc && (
         <figure className={largeClasses('image')}>
-          {linkedItem(
+          <LinkedItem url={url}>
             <img
               typeof="foaf:Image"
               src={imgSrc}
               alt={imgAlt}
               className={largeClasses('img')}
-            />,
-            url
-          )}
+            />
+          </LinkedItem>
         </figure>
       )}
-      <div className={largeClasses('blurb')}>
+      <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
         {blurb}
         {hasAudio && (
           <a className={styles.iconLink} href={url}>
             <Icon name="volume" className={styles.icon} isRoundIcon />
           </a>
         )}
-      </div>
+      </BlurbContent>
     </article>
   );
 };

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -98,14 +98,14 @@ const CardItem = ({
           )}
         </figure>
       )}
-      <p className={largeClasses('blurb')}>
+      <div className={largeClasses('blurb')}>
         {blurb}
         {hasAudio && (
           <a className={styles.iconLink} href={url}>
             <Icon name="volume" className={styles.icon} isRoundIcon />
           </a>
         )}
-      </p>
+      </div>
     </article>
   );
 };

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -84,7 +84,6 @@
 
 .blurb {
   flex: 0 1 100%;
-  margin-top: 1rem;
 }
 
 .blurbLg {

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -84,6 +84,11 @@
 
 .blurb {
   flex: 0 1 100%;
+  margin-top: 1rem;
+}
+
+div.blurb {
+  margin-top: 0;
 }
 
 .blurbLg {

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -43,11 +43,11 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
       />
     </a>
   </figure>
-  <p
+  <div
     className="blurb"
   >
     Test Teaser
-  </p>
+  </div>
 </article>
 `;
 
@@ -79,7 +79,7 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
       property="sioc:num_replies"
     />
   </div>
-  <p
+  <div
     className="blurb blurbLg"
   />
 </article>
@@ -118,7 +118,7 @@ exports[`<CardItem /> Matches the Card Item No Link  snapshot 1`] = `
       typeof="foaf:Image"
     />
   </figure>
-  <p
+  <div
     className="blurb"
   />
 </article>

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -16,6 +16,7 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
         href="/"
       >
         Test Title
+        ,
       </a>
     </h2>
     <span
@@ -32,7 +33,7 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
     className="image"
   >
     <a
-      className=""
+      className={null}
       href="/"
     >
       <img
@@ -43,11 +44,11 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
       />
     </a>
   </figure>
-  <div
+  <p
     className="blurb"
   >
     Test Teaser
-  </div>
+  </p>
 </article>
 `;
 
@@ -67,6 +68,7 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
         href="/"
       >
         Test Title
+        ,
       </a>
     </h2>
     <span
@@ -79,7 +81,7 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
       property="sioc:num_replies"
     />
   </div>
-  <div
+  <p
     className="blurb blurbLg"
   />
 </article>
@@ -97,6 +99,7 @@ exports[`<CardItem /> Matches the Card Item No Link  snapshot 1`] = `
       className="title freeformTitle"
     >
       Test Title
+      ,
     </h2>
     <span
       content="Test Title"


### PR DESCRIPTION
**This PR does the following:**
- Makes the freeform CardList content render in a div, all other card list types render in a paragraph.
- Improves the CardItem component's approach to conditional rendering.

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Navigate to the [Freeform CardItem](http://localhost:9001/?selectedKind=Molecules%2FCardItem&selectedStory=Freeform&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
- [x] Note that it's blurb is a `div`.
- [x] Note that all other CardItem's blurbs are rendered in a paragraph.
- [ ] Note that the image and title rendered output are no different than before (improvements don't break anything).