### PR TITLE
HOTFIX: tweak teaserList header style

### DIFF
--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -99,7 +99,7 @@ const CardItem = ({
               url={url}
               className={`${styles.link} ${freeformClasses('freeformLink')}`}
             >
-              {title},
+              {title}
             </LinkedItem>
           </h2>
         )}

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -16,7 +16,6 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
         href="/"
       >
         Test Title
-        ,
       </a>
     </h2>
     <span
@@ -68,7 +67,6 @@ exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
         href="/"
       >
         Test Title
-        ,
       </a>
     </h2>
     <span
@@ -99,7 +97,6 @@ exports[`<CardItem /> Matches the Card Item No Link  snapshot 1`] = `
       className="title freeformTitle"
     >
       Test Title
-      ,
     </h2>
     <span
       content="Test Title"

--- a/src/components/Organisms/Teaser/TeaserList.css
+++ b/src/components/Organisms/Teaser/TeaserList.css
@@ -7,10 +7,13 @@
 }
 
 .header {
+  border-top: 3px solid #ddd;
   padding: 10px 15px;
   font-size: 1rem;
-  border-top: 3px solid grayLight;
+  line-height: 1.2;
   color: grayDark;
+  margin: 0;
+  font-family: 'Raleway', sans-serif;
 }
 
 .footer {

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1515,6 +1515,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco
+                ,
               </a>
             </h2>
             <span
@@ -1531,7 +1532,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image imageLg"
           >
             <a
-              className=""
+              className={null}
               href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
             >
               <img
@@ -1582,6 +1583,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 50 years on, India is celebrating the Beatles' infamous trip to the country
+                ,
               </a>
             </h2>
             <span
@@ -1598,7 +1600,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image"
           >
             <a
-              className=""
+              className={null}
               href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
             >
               <img
@@ -1630,6 +1632,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 Progressives in Congress side with Trump on trade
+                ,
               </a>
             </h2>
             <span
@@ -1646,7 +1649,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image"
           >
             <a
-              className=""
+              className={null}
               href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
             >
               <img
@@ -1697,6 +1700,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="https://interactive-dev.pri.org/stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 A cartoonist in Equatorial Guinea has been cleared of charges, but he's still in jail
+                ,
               </a>
             </h2>
             <span
@@ -1713,7 +1717,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image"
           >
             <a
-              className=""
+              className={null}
               href="https://interactive-dev.pri.org/stories/2017-07-24/clearing-mines-and-explosives-mosul"
             >
               <img
@@ -1741,6 +1745,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               className="title "
             >
               Egyptian singer faces the prospect of prison over a joke about the Nile
+              ,
             </h2>
             <span
               content="Egyptian singer faces the prospect of prison over a joke about the Nile"
@@ -2151,6 +2156,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="#"
               >
                 How the murder of a young woman turned Italy's elections into a referendum on immigration
+                ,
               </a>
             </h2>
             <span
@@ -2167,7 +2173,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image imageLg"
           >
             <a
-              className=""
+              className={null}
               href="#"
             >
               <img
@@ -2199,6 +2205,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 Instagram art project spreads awareness about femicides in Mexico
+                ,
               </a>
             </h2>
             <span
@@ -2215,7 +2222,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image"
           >
             <a
-              className=""
+              className={null}
               href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
             >
               <img
@@ -2247,6 +2254,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 When this Univision anchor interviewed a head of the KKK, he called her the n-word
+                ,
               </a>
             </h2>
             <span
@@ -2263,7 +2271,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             className="image"
           >
             <a
-              className=""
+              className={null}
               href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
             >
               <img

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1515,7 +1515,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco
-                ,
               </a>
             </h2>
             <span
@@ -1583,7 +1582,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 50 years on, India is celebrating the Beatles' infamous trip to the country
-                ,
               </a>
             </h2>
             <span
@@ -1632,7 +1630,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 Progressives in Congress side with Trump on trade
-                ,
               </a>
             </h2>
             <span
@@ -1700,7 +1697,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="https://interactive-dev.pri.org/stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 A cartoonist in Equatorial Guinea has been cleared of charges, but he's still in jail
-                ,
               </a>
             </h2>
             <span
@@ -1745,7 +1741,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               className="title "
             >
               Egyptian singer faces the prospect of prison over a joke about the Nile
-              ,
             </h2>
             <span
               content="Egyptian singer faces the prospect of prison over a joke about the Nile"
@@ -2156,7 +2151,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="#"
               >
                 How the murder of a young woman turned Italy's elections into a referendum on immigration
-                ,
               </a>
             </h2>
             <span
@@ -2205,7 +2199,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 Instagram art project spreads awareness about femicides in Mexico
-                ,
               </a>
             </h2>
             <span
@@ -2254,7 +2247,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
                 When this Univision anchor interviewed a head of the KKK, he called her the n-word
-                ,
               </a>
             </h2>
             <span


### PR DESCRIPTION
**This PR does the following:**
- Addresses a minor styling issue on the Latest Content teaser list PR: https://github.com/PublicRadioInternational/pri-frontend/pull/15 

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Go [here](http://localhost:9001/?selectedKind=Organisms%2FTeaserList&selectedStory=Article%20List&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) and ensure the styling of the Latest Content header text matches the text found in the [prototype](https://interactive-dev.pri.org/staging/prototypes/homepage/iteration-2.html)
