### PR TITLE
PRIAPI-158: consistent card list title height

### DIFF
--- a/src/components/Organisms/CardList/CardList.component.js
+++ b/src/components/Organisms/CardList/CardList.component.js
@@ -19,7 +19,7 @@ const CardList = ({ category, children, url, src, categoryDescription }) => (
         {src && (
           <img src={src} alt={categoryDescription} className={styles.logo} />
         )}
-        {categoryDescription}
+        <span>{categoryDescription}</span>
       </a>
     </header>
     {children}

--- a/src/components/Organisms/CardList/CardList.css
+++ b/src/components/Organisms/CardList/CardList.css
@@ -91,19 +91,22 @@
 
 .header {
   border-bottom: 1px solid grayLighter;
+  min-height: 50px;
   padding: 0.5rem 1rem 0.7rem;
   font-family: heading;
 }
 
 .logoLink {
   align-items: center;
+  color: blue;
   display: flex;
   font-weight: bold;
+  min-height: 50px;
   text-decoration: none;
-  color: blue;
 }
 
 .logo {
+  display: block;
   margin-right: 10px;
   width: 50px;
 }

--- a/src/components/Organisms/CardList/CardList.css
+++ b/src/components/Organisms/CardList/CardList.css
@@ -91,7 +91,6 @@
 
 .header {
   border-bottom: 1px solid grayLighter;
-  min-height: 50px;
   padding: 0.5rem 1rem 0.7rem;
   font-family: heading;
 }

--- a/src/components/Organisms/CardList/__snapshots__/CardList.test.js.snap
+++ b/src/components/Organisms/CardList/__snapshots__/CardList.test.js.snap
@@ -16,7 +16,9 @@ exports[`<CardList /> Matches the Card List snapshot 1`] = `
         className="logo"
         src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
       />
-      PRIs The World
+      <span>
+        PRIs The World
+      </span>
     </a>
   </header>
   <span>

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -23,7 +23,7 @@ import BlockList from './BlockList/BlockList.component';
  */
 storiesOf('Organisms/CardList', module)
   .addDecorator(checkA11y)
-  .add('Card List', () => (
+  .add('Card List with Image', () => (
     <CardList
       src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
       category="pris-the-world"
@@ -66,6 +66,41 @@ storiesOf('Organisms/CardList', module)
         imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
         imgAlt="Alt Text"
         blurb="An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'"
+        hasAudio
+      />
+    </CardList>
+  ));
+
+storiesOf('Organisms/CardList', module)
+  .addDecorator(checkA11y)
+  .add('Without Image', () => (
+    <CardList
+      category="pris-the-world"
+      url="#"
+      categoryDescription="PRIs The World"
+    >
+      <CardItem
+        title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgAlt="Alt Text"
+        blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
+        large
+        hasAudio
+      />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+      />
+      <CardItem
+        title="Progressives in Congress side with Trump on trade"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
+        imgAlt="Alt Text"
+        blurb="NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. "
         hasAudio
       />
     </CardList>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1497,7 +1497,9 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               className="logo"
               src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
             />
-            PRIs The World
+            <span>
+              PRIs The World
+            </span>
           </a>
         </header>
         <article
@@ -2320,7 +2322,9 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               className="logo"
               src="https://media.pri.org/s3fs-public/styles/medium_square/public/logo_gp.png"
             />
-            GlobalPost
+            <span>
+              GlobalPost
+            </span>
           </a>
         </header>
         <article


### PR DESCRIPTION
## [PRIAPI-158: consistent card list title height](https://fourkitchens.atlassian.net/browse/PRIAPI-158)

**This PR does the following:**
- Adds consistent height to the card title [with](http://localhost:9001/?selectedKind=Organisms%2FCardList&selectedStory=Card%20List%20with%20Image&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) or [without](http://localhost:9001/?selectedKind=Organisms%2FCardList&selectedStory=Without%20Image&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) the image

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start` and verify the card list headers match [with](http://localhost:9001/?selectedKind=Organisms%2FCardList&selectedStory=Card%20List%20with%20Image&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) or [without](http://localhost:9001/?selectedKind=Organisms%2FCardList&selectedStory=Without%20Image&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) the image
