### PR TITLE
fix(sticky): move to different sticky library

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "postcss-mixins": "^6.2.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-sticky-fill": "^0.8.4"
+    "react-sticky-el": "^1.0.16"
   }
 }

--- a/src/components/00_global/breakpoints.css
+++ b/src/components/00_global/breakpoints.css
@@ -4,6 +4,8 @@
 
 @value medium: (min-width: 768px);
 
+@value max-medium: (max-width: 768px);
+
 @value header: (min-width: 884px);
 
 @value maxWidth: (min-width: 1240px);

--- a/src/components/Molecules/StickyItem/StickyItem.component.js
+++ b/src/components/Molecules/StickyItem/StickyItem.component.js
@@ -3,7 +3,7 @@
  * Exports a Sticky component (sticks to window on scroll).
  */
 
-import Sticky from 'react-sticky-fill';
+import Sticky from 'react-sticky-el';
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './StickyItem.css';
@@ -12,7 +12,13 @@ import styles from './StickyItem.css';
  * Component that renders a Sticky Element.
  */
 const StickyItem = ({ children }) => (
-  <Sticky className={`sticky ${styles.sticky}`}>{children}</Sticky>
+  <Sticky
+    hideOnBoundaryHit={false}
+    boundaryElement="main"
+    className={styles.sticky}
+  >
+    {children}
+  </Sticky>
 );
 
 StickyItem.propTypes = {

--- a/src/components/Molecules/StickyItem/StickyItem.css
+++ b/src/components/Molecules/StickyItem/StickyItem.css
@@ -1,10 +1,9 @@
 /* import breakpoints */
-@value header as bp-header from "../../00_global/breakpoints.css";
+@value max-medium as bp-medium from "../../00_global/breakpoints.css";
 
-@media bp-header {
+/* Disable sticky on mobile */
+@media bp-medium {
   .sticky {
-    position: sticky;
-    top: 0;
-    z-index: 1;
+    position: relative !important;
   }
 }

--- a/src/components/Organisms/Main/Main.css
+++ b/src/components/Organisms/Main/Main.css
@@ -85,6 +85,7 @@
     -ms-grid-row-span: 2;
     grid-column: 3 / span 1;
     grid-row: 1 / span 2;
+    position: relative;
   }
 
   .callouts {

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,13 +225,6 @@
     lodash "^4.17.4"
     url-template "^2.0.8"
 
-"@researchgate/react-intersection-observer@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@researchgate/react-intersection-observer/-/react-intersection-observer-0.6.0.tgz#505f20b62c8941a035442b61ac448870afb5d8a2"
-  dependencies:
-    invariant "^2.2.2"
-    prop-types "^15.6.0"
-
 "@semantic-release/commit-analyzer@^5.0.0":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.2.tgz#4db92f1aaed02397393ac78309892627c88eb64a"
@@ -2845,10 +2838,6 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-supports@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/css-supports/-/css-supports-0.1.1.tgz#9ae201f952beb65f00c5e4b249ebce8ef58a013d"
-
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
@@ -4794,10 +4783,6 @@ inquirer@^3.0.6:
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
-
-intersection-observer@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.0.tgz#9fe8bee3953c755b1485c38efd9633d535775ea6"
 
 into-stream@^3.1.0:
   version "3.1.0"
@@ -7284,7 +7269,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@>=15.5.10, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -7541,12 +7526,11 @@ react-split-pane@^0.1.74:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-sticky-fill@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/react-sticky-fill/-/react-sticky-fill-0.8.4.tgz#8870a71b1c356b5caf2c451ff0010fdfa0de6111"
+react-sticky-el@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/react-sticky-el/-/react-sticky-el-1.0.16.tgz#21eb464bbaaeb2b05e7d27d0184a9213c49240dd"
   dependencies:
-    css-supports "^0.1.1"
-    stickyfill "^1.1.1"
+    prop-types ">=15.5.10"
 
 react-style-proptype@^3.0.0:
   version "3.2.0"
@@ -8480,10 +8464,6 @@ statuses@~1.3.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-
-stickyfill@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stickyfill/-/stickyfill-1.1.1.tgz#39413fee9d025c74a7e59ceecb23784cc0f17f02"
 
 stream-browserify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This is fully tested with both storybook, mobile, and frontend build! But... it fails creating new snapshots. Needs a little kicking, and likely another set of eyes.