### PR TITLE
Hotfix/sticky lib loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "html-react-parser": "^0.4.3",
     "postcss-mixins": "^6.2.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-sticky-fill": "^0.8.4"
+    "react-dom": "^16.2.0"
   }
 }

--- a/src/components/Molecules/StickyItem/StickyItem.component.js
+++ b/src/components/Molecules/StickyItem/StickyItem.component.js
@@ -8,6 +8,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './StickyItem.css';
 
+global.window = {
+  addEventListener: Sticky,
+  removeEventListener: Sticky
+};
+
 /**
  * Component that renders a Sticky Element.
  */

--- a/src/components/Molecules/StickyItem/StickyItem.component.js
+++ b/src/components/Molecules/StickyItem/StickyItem.component.js
@@ -3,21 +3,15 @@
  * Exports a Sticky component (sticks to window on scroll).
  */
 
-import Sticky from 'react-sticky-fill';
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './StickyItem.css';
-
-global.window = {
-  addEventListener: Sticky,
-  removeEventListener: Sticky
-};
 
 /**
  * Component that renders a Sticky Element.
  */
 const StickyItem = ({ children }) => (
-  <Sticky className={`sticky ${styles.sticky}`}>{children}</Sticky>
+  <div className={`${styles.sticky}`}>{children}</div>
 );
 
 StickyItem.propTypes = {

--- a/src/components/Molecules/StickyItem/StickyItem.css
+++ b/src/components/Molecules/StickyItem/StickyItem.css
@@ -5,6 +5,5 @@
   .sticky {
     position: sticky;
     top: 0;
-    z-index: 1;
   }
 }

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1793,14 +1793,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       className="className && latestContent"
     >
       <div
-        className="sticky sticky"
-        style={
-          Object {
-            "position": "sticky",
-            "top": 0,
-            "zIndex": 1,
-          }
-        }
+        className="sticky"
       >
         <section
           className="className && section"


### PR DESCRIPTION
## hotfix for removing `position: sticky` polyfill for IE11

**This PR does the following:**
- Removes that library, simplifies styles

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start` and verify everything works OK in frontend app
