### PR TITLE
fix(main): normalize spacing of sections and cardlists

### DIFF
--- a/src/components/Organisms/CardList/CardList.css
+++ b/src/components/Organisms/CardList/CardList.css
@@ -11,6 +11,11 @@
   border-top: 3px solid #ddd;
   border-radius: 0.25rem;
   word-wrap: break-word;
+  margin-bottom: 1rem;
+}
+
+.list:last-child {
+  margin-bottom: 0;
 }
 
 .america-abroad {

--- a/src/components/Organisms/Footer/Footer.css
+++ b/src/components/Organisms/Footer/Footer.css
@@ -6,6 +6,7 @@
 @value copy from fonts;
 
 .siteFooter {
+  margin-top: 2rem;
   background: grayLighter;
   clear: both;
 }

--- a/src/components/Organisms/Footer/Footer.css
+++ b/src/components/Organisms/Footer/Footer.css
@@ -6,7 +6,6 @@
 @value copy from fonts;
 
 .siteFooter {
-  margin-top: 2rem;
   background: grayLighter;
   clear: both;
 }

--- a/src/components/Organisms/Main/Main.css
+++ b/src/components/Organisms/Main/Main.css
@@ -37,15 +37,10 @@
   }
 }
 
-.mainList2,
+.mainList,
 .latestContent,
 .callouts {
-  margin-top: 2rem;
-}
-
-.mainList > * + *,
-.mainList2 > * + * {
-  margin-top: 1rem;
+  margin-bottom: 2rem;
 }
 
 @media bp-medium {
@@ -56,18 +51,14 @@
     width: 64%;
   }
 
-  .mainList2 {
-    margin-top: 1rem;
+  .mainList {
+    margin-bottom: 1rem;
   }
 
   .latestContent,
   .callouts {
     float: right;
     width: 33%;
-  }
-
-  .latestContent {
-    margin-top: 0;
   }
 }
 
@@ -78,10 +69,6 @@
   .callouts {
     float: none;
     width: auto;
-  }
-
-  .callouts {
-    margin-top: 0;
   }
 
   .mainContainer {

--- a/src/components/Organisms/Main/Main.css
+++ b/src/components/Organisms/Main/Main.css
@@ -94,6 +94,7 @@
     -ms-grid-row-span: 2;
     grid-column: 3 / span 1;
     grid-row: 1 / span 2;
+    margin-bottom: 0;
   }
 
   .callouts {

--- a/src/components/Organisms/Main/Main.css
+++ b/src/components/Organisms/Main/Main.css
@@ -25,17 +25,27 @@
   max-width: 1200px;
 }
 
+.mainContainer:after {
+  content: '';
+  display: block;
+  clear: both;
+}
+
 @media bp-maxWidth {
   .mainContainer {
     margin: 1rem auto 2rem;
   }
 }
 
-.mainList,
 .mainList2,
 .latestContent,
 .callouts {
-  margin-bottom: 2rem;
+  margin-top: 2rem;
+}
+
+.mainList > * + *,
+.mainList2 > * + * {
+  margin-top: 1rem;
 }
 
 @media bp-medium {
@@ -46,10 +56,18 @@
     width: 64%;
   }
 
+  .mainList2 {
+    margin-top: 1rem;
+  }
+
   .latestContent,
   .callouts {
     float: right;
     width: 33%;
+  }
+
+  .latestContent {
+    margin-top: 0;
   }
 }
 
@@ -60,6 +78,10 @@
   .callouts {
     float: none;
     width: auto;
+  }
+
+  .callouts {
+    margin-top: 0;
   }
 
   .mainContainer {

--- a/src/components/Pages/Home/Home.component.js
+++ b/src/components/Pages/Home/Home.component.js
@@ -287,6 +287,29 @@ const Home = ({ baseUrl }) => (
             hasAudio
           />
         </CardList>
+        <CardList
+          src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
+          category="pris-the-world"
+          url="#"
+          categoryDescription="PRIs The World"
+        >
+          <CardItem
+            title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+            url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+            imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+            imgAlt="Alt Text"
+            blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
+            large
+            hasAudio
+          />
+          <CardItem
+            title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+            url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+            imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+            imgAlt="Alt Text"
+            blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+          />
+        </CardList>
       </LayoutMainList2>
     </LayoutMain>
     <Footer />

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -2484,6 +2484,142 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
       </section>
+      <section
+        className="className && list pris-the-world"
+      >
+        <header
+          className="header"
+        >
+          <a
+            className="logoLink"
+            href="#"
+          >
+            <img
+              alt="PRIs The World"
+              className="logo"
+              src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
+            />
+            <span>
+              PRIs The World
+            </span>
+          </a>
+        </header>
+        <article
+          className="cardItem cardItemLg"
+          typeof="sioc:Item foaf:Document"
+        >
+          <div
+            className="titleWrap titleWrapLg"
+          >
+            <h2
+              className=" "
+            >
+              <a
+                className="link "
+                href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+              >
+                There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco
+              </a>
+            </h2>
+            <span
+              content="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+              property="dc:title"
+            />
+            <span
+              content="0"
+              datatype="xsd:integer"
+              property="sioc:num_replies"
+            />
+          </div>
+          <figure
+            className="image imageLg"
+          >
+            <a
+              className={null}
+              href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+            >
+              <img
+                alt="Alt Text"
+                className="img imgLg"
+                src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+                typeof="foaf:Image"
+              />
+            </a>
+          </figure>
+          <p
+            className="blurb blurbLg"
+          >
+            Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food.
+            <a
+              className="iconLink"
+              href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+            >
+              <svg
+                aria-hidden={null}
+                aria-labelledby={null}
+                className="svg icon roundIcon"
+                fill="currentcolor"
+                height={28}
+                version={1.1}
+                viewBox="0 0 28 28"
+                width={28}
+              >
+                <path
+                  d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
+                />
+              </svg>
+            </a>
+          </p>
+        </article>
+        <article
+          className="cardItem"
+          typeof="sioc:Item foaf:Document"
+        >
+          <div
+            className="titleWrap"
+          >
+            <h2
+              className="title "
+            >
+              <a
+                className="link "
+                href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+              >
+                50 years on, India is celebrating the Beatles' infamous trip to the country
+              </a>
+            </h2>
+            <span
+              content="50 years on, India is celebrating the Beatles' infamous trip to the country"
+              property="dc:title"
+            />
+            <span
+              content="0"
+              datatype="xsd:integer"
+              property="sioc:num_replies"
+            />
+          </div>
+          <figure
+            className="image"
+          >
+            <a
+              className={null}
+              href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+            >
+              <img
+                alt="Alt Text"
+                className="img"
+                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+                typeof="foaf:Image"
+              />
+            </a>
+          </figure>
+          <p
+            className="blurb"
+          >
+            When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. 
+          </p>
+        </article>
+      </section>
     </section>
   </main>
   <footer

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,13 +225,6 @@
     lodash "^4.17.4"
     url-template "^2.0.8"
 
-"@researchgate/react-intersection-observer@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@researchgate/react-intersection-observer/-/react-intersection-observer-0.6.0.tgz#505f20b62c8941a035442b61ac448870afb5d8a2"
-  dependencies:
-    invariant "^2.2.2"
-    prop-types "^15.6.0"
-
 "@semantic-release/commit-analyzer@^5.0.0":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.2.tgz#4db92f1aaed02397393ac78309892627c88eb64a"
@@ -2845,10 +2838,6 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-supports@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/css-supports/-/css-supports-0.1.1.tgz#9ae201f952beb65f00c5e4b249ebce8ef58a013d"
-
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
@@ -4794,10 +4783,6 @@ inquirer@^3.0.6:
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
-
-intersection-observer@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.0.tgz#9fe8bee3953c755b1485c38efd9633d535775ea6"
 
 into-stream@^3.1.0:
   version "3.1.0"
@@ -7541,13 +7526,6 @@ react-split-pane@^0.1.74:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-sticky-fill@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/react-sticky-fill/-/react-sticky-fill-0.8.4.tgz#8870a71b1c356b5caf2c451ff0010fdfa0de6111"
-  dependencies:
-    css-supports "^0.1.1"
-    stickyfill "^1.1.1"
-
 react-style-proptype@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.0.tgz#be5de15358b890d83aecfaf6634cc033aa2b1483"
@@ -8480,10 +8458,6 @@ statuses@~1.3.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-
-stickyfill@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stickyfill/-/stickyfill-1.1.1.tgz#39413fee9d025c74a7e59ceecb23784cc0f17f02"
 
 stream-browserify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
**This PR does the following:**
- Space between LayoutMainList and LayoutMainList2 should be `1rem`
- Space between CardList siblings should be `1rem`
- LayoutMain should clear floated children non-desktop sizes

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn ; yarn start`.
- [ ] Verify sections and card lists are nicely spaced at all device sizes.
