### PR TITLE
PRIAPI-153: Lazy Load

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,24 @@
 {
-  "presets": ["env", "stage-0", "react"],
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["last 2 versions", "Explorer 11"]
+        },
+        "useBuiltIns": true
+      }
+    ],
+    "stage-0",
+    "react"
+  ],
   "plugins": [
     "babel-plugin-macros",
-    ["transform-runtime", {
-      "polyfill": false,
-      "regenerator": true
-    }]
+    [
+      "transform-runtime",
+      {
+        "regenerator": true
+      }
+    ]
   ]
 }

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,6 +3,7 @@
  * Contains configuration for Storybook.
  */
 
+require('babel-polyfill');
 import { configure } from '@storybook/react';
 
 import styles from '../src/components/00_global/reset.css';
@@ -20,3 +21,5 @@ const loadStories = () => {
 
 // Configure storybook.
 configure(loadStories, module);
+
+window.scrollTo(0, 0);

--- a/__mocks__/intersection-observer.js
+++ b/__mocks__/intersection-observer.js
@@ -1,0 +1,13 @@
+/**
+ * @file intersection-observer.js
+ * Mocks the intersection observer polyfill.
+ */
+/* eslint-disable */
+(function(window, document) {
+  function IntersectionObserverEntry(entry) {}
+
+  function IntersectionObserver(callback, opt_options) {}
+
+  window.IntersectionObserver = IntersectionObserver;
+  window.IntersectionObserverEntry = IntersectionObserverEntry;
+})(window, document);

--- a/__mocks__/intersection-observer.js
+++ b/__mocks__/intersection-observer.js
@@ -8,6 +8,8 @@
 
   function IntersectionObserver(callback, opt_options) {}
 
+  IntersectionObserver.prototype.observe = function() {};
+
   window.IntersectionObserver = IntersectionObserver;
   window.IntersectionObserverEntry = IntersectionObserverEntry;
 })(window, document);

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ import LayoutAsideLatest from './src/components/Organisms/Main/LayoutAsideLatest
 import LayoutMain from './src/components/Organisms/Main/LayoutMain.component';
 import LayoutMainList from './src/components/Organisms/Main/LayoutMainList.component';
 import LayoutMainList2 from './src/components/Organisms/Main/LayoutMainList2.component';
+import LazyLoad from './src/components/Atoms/LazyLoad/LazyLoad.component';
 import Main from './src/components/Organisms/Main/Main.component';
 import Home from './src/components/Pages/Home/Home.component';
 
@@ -51,6 +52,7 @@ export {
   ButtonInput,
   ButtonLink,
   DropdownItem,
+  LazyLoad,
   Icons,
   PriLogo,
   // Molecules.

--- a/package.json
+++ b/package.json
@@ -87,10 +87,12 @@
     "access": "restricted"
   },
   "dependencies": {
+    "@researchgate/react-intersection-observer": "^0.6.0",
     "babel-plugin-macros": "^2.2.0",
     "babel-preset-stage-0": "^6.24.1",
     "classnames": "^2.2.5",
     "downshift": "^1.30.0",
+    "intersection-observer": "^0.5.0",
     "postcss-mixins": "^6.2.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "dependencies": {
     "@researchgate/react-intersection-observer": "^0.6.0",
     "babel-plugin-macros": "^2.2.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-stage-0": "^6.24.1",
     "classnames": "^2.2.5",
     "downshift": "^1.30.0",

--- a/src/components/00_global/global.css
+++ b/src/components/00_global/global.css
@@ -57,7 +57,7 @@ img {
   height: auto;
   max-width: 100%;
   opacity: 1;
-  transition: all 0.5s;
+  transition: opacity 0.5s;
 }
 
 iframe,

--- a/src/components/00_global/global.css
+++ b/src/components/00_global/global.css
@@ -47,15 +47,17 @@ a:hover {
   color: orange;
 }
 
+img[data-src] {
+  height: 0;
+  opacity: 0;
+  overflow: hidden;
+}
+
 img {
   height: auto;
   max-width: 100%;
   opacity: 1;
-  transition: opacity 0.5s;
-}
-
-img[data-src] {
-  opacity: 0;
+  transition: all 0.5s;
 }
 
 iframe,

--- a/src/components/00_global/global.css
+++ b/src/components/00_global/global.css
@@ -50,6 +50,12 @@ a:hover {
 img {
   height: auto;
   max-width: 100%;
+  opacity: 1;
+  transition: opacity 0.5s;
+}
+
+img[data-src] {
+  opacity: 0;
 }
 
 iframe,

--- a/src/components/Atoms/LazyLoad/LazyLoad.component.js
+++ b/src/components/Atoms/LazyLoad/LazyLoad.component.js
@@ -3,7 +3,7 @@
  * Exports a lazy load component.
  */
 
-import 'intersection-observer'; // optional polyfill
+import 'intersection-observer';
 import Observer from '@researchgate/react-intersection-observer';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/Atoms/LazyLoad/LazyLoad.component.js
+++ b/src/components/Atoms/LazyLoad/LazyLoad.component.js
@@ -1,0 +1,38 @@
+/**
+ * @file LazyLoad.component.js
+ * Exports a lazy load component.
+ */
+
+import 'intersection-observer'; // optional polyfill
+import Observer from '@researchgate/react-intersection-observer';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Component that renders a Card Item.
+ */
+export default class LazyLoad extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired
+  };
+
+  loadImage = item => {
+    if (item.isIntersecting) {
+      const element = item.target;
+      const { src } = element.dataset;
+      element.src = src;
+      element.addEventListener('load', () => {
+        element.removeAttribute('data-src');
+      });
+    }
+  };
+
+  render() {
+    const { children } = this.props;
+    return (
+      <Observer onChange={this.loadImage} onlyOnce rootMargin="0% 0% 25%">
+        {children}
+      </Observer>
+    );
+  }
+}

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -122,7 +122,9 @@ const CardItem = ({
         </figure>
       )}
       <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
-        {blurb ? <div dangerouslySetInnerHTML={{ __html: blurb }} /> : null}
+        {blurb ? (
+          <div dangerouslySetInnerHTML={{ __html: blurb }} />
+        ) : null /* eslint-disable-line */}
         {hasAudio && (
           <a className={styles.iconLink} href={url}>
             <Icon

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -3,14 +3,13 @@
  * Exports a card item component.
  */
 
-import 'intersection-observer'; // optional polyfill
-import Observer from '@researchgate/react-intersection-observer';
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './CardItem.css';
 
 import Icon from '../../Atoms/Svg/Icons.component';
+import LazyLoad from '../../Atoms/LazyLoad/LazyLoad.component';
 
 const cx = classNames.bind(styles);
 
@@ -61,132 +60,104 @@ BlurbContent.defaultProps = {
   className: null
 };
 
-const fetchImage = url =>
-  new Promise((resolve, reject) => {
-    const image = new Image();
-    image.src = url;
-    image.onload = resolve;
-    image.onerror = reject;
-  });
-
 /**
  * Component that renders a Card Item.
  */
-export default class CardItem extends Component {
-  static propTypes = {
-    url: PropTypes.string,
-    title: PropTypes.string,
-    imgSrc: PropTypes.string,
-    imgAlt: PropTypes.string,
-    blurb: PropTypes.node,
-    large: PropTypes.bool,
-    hasAudio: PropTypes.bool,
-    freeform: PropTypes.bool
-  };
+const CardItem = ({
+  url,
+  title,
+  imgSrc,
+  imgAlt,
+  blurb,
+  large,
+  hasAudio,
+  freeform
+}) => {
+  const largeClasses = element =>
+    cx({
+      [element]: true,
+      [`${element}Lg`]: large
+    });
 
-  static defaultProps = {
-    imgSrc: null,
-    imgAlt: null,
-    blurb: null,
-    url: null,
-    title: null,
-    large: false,
-    hasAudio: false,
-    freeform: false
-  };
+  const freeformClasses = element =>
+    cx({
+      [element]: freeform
+    });
 
-  loadImage = image => {
-    if (image.isIntersecting) {
-      const img = image.target;
-      const src = img.dataset.src; // eslint-disable-line
-      fetchImage(src).then(() => {
-        img.src = src;
-        img.removeAttribute('data-src');
-      });
-    }
-  };
-
-  render() {
-    const {
-      url,
-      title,
-      imgSrc,
-      imgAlt,
-      blurb,
-      large,
-      hasAudio,
-      freeform
-    } = this.props;
-    const largeClasses = element =>
-      cx({
-        [element]: true,
-        [`${element}Lg`]: large
-      });
-
-    const freeformClasses = element =>
-      cx({
-        [element]: freeform
-      });
-
-    return (
-      <article
-        className={largeClasses('cardItem')}
-        typeof="sioc:Item foaf:Document"
-      >
-        <div className={largeClasses('titleWrap')}>
-          {title && (
-            <h2
-              className={`${!large ? styles.title : ''} ${freeformClasses(
-                'freeformTitle'
-              )}`}
+  return (
+    <article
+      className={largeClasses('cardItem')}
+      typeof="sioc:Item foaf:Document"
+    >
+      <div className={largeClasses('titleWrap')}>
+        {title && (
+          <h2
+            className={`${!large ? styles.title : ''} ${freeformClasses(
+              'freeformTitle'
+            )}`}
+          >
+            <LinkedItem
+              url={url}
+              className={`${styles.link} ${freeformClasses('freeformLink')}`}
             >
-              <LinkedItem
-                url={url}
-                className={`${styles.link} ${freeformClasses('freeformLink')}`}
-              >
-                {title}
-              </LinkedItem>
-            </h2>
-          )}
-          {title && <span property="dc:title" content={title} />}
-          <span
-            property="sioc:num_replies"
-            content="0"
-            datatype="xsd:integer"
-          />
-        </div>
-        {imgSrc && (
-          <figure className={largeClasses('image')}>
-            <LinkedItem url={url}>
-              <Observer
-                onChange={this.loadImage}
-                onlyOnce
-                rootMargin="0% 0% 25%"
-              >
-                <img
-                  typeof="foaf:Image"
-                  data-src={imgSrc}
-                  alt={imgAlt}
-                  className={largeClasses('img')}
-                />
-              </Observer>
+              {title}
             </LinkedItem>
-          </figure>
+          </h2>
         )}
-        <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
-          {blurb ? <div dangerouslySetInnerHTML={{ __html: blurb }} /> : null}
-          {hasAudio && (
-            <a className={styles.iconLink} href={url}>
-              <Icon
-                name="volume"
-                className={styles.icon}
-                isRoundIcon
-                ariaLabel="Audio"
+        {title && <span property="dc:title" content={title} />}
+        <span property="sioc:num_replies" content="0" datatype="xsd:integer" />
+      </div>
+      {imgSrc && (
+        <figure className={largeClasses('image')}>
+          <LinkedItem url={url}>
+            <LazyLoad>
+              <img
+                typeof="foaf:Image"
+                data-src={imgSrc}
+                alt={imgAlt}
+                className={largeClasses('img')}
               />
-            </a>
-          )}
-        </BlurbContent>
-      </article>
-    );
-  }
-}
+            </LazyLoad>
+          </LinkedItem>
+        </figure>
+      )}
+      <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
+        {blurb ? <div dangerouslySetInnerHTML={{ __html: blurb }} /> : null}
+        {hasAudio && (
+          <a className={styles.iconLink} href={url}>
+            <Icon
+              name="volume"
+              className={styles.icon}
+              isRoundIcon
+              ariaLabel="Audio"
+            />
+          </a>
+        )}
+      </BlurbContent>
+    </article>
+  );
+};
+
+CardItem.propTypes = {
+  url: PropTypes.string,
+  title: PropTypes.string,
+  imgSrc: PropTypes.string,
+  imgAlt: PropTypes.string,
+  blurb: PropTypes.node,
+  large: PropTypes.bool,
+  hasAudio: PropTypes.bool,
+  freeform: PropTypes.bool
+};
+
+CardItem.defaultProps = {
+  imgSrc: null,
+  imgAlt: null,
+  blurb: null,
+  url: null,
+  title: null,
+  large: false,
+  hasAudio: false,
+  freeform: false
+};
+
+export default CardItem;

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -3,7 +3,9 @@
  * Exports a card item component.
  */
 
-import React from 'react';
+import 'intersection-observer'; // optional polyfill
+import Observer from '@researchgate/react-intersection-observer';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './CardItem.css';
@@ -59,102 +61,132 @@ BlurbContent.defaultProps = {
   className: null
 };
 
+const fetchImage = url =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.src = url;
+    image.onload = resolve;
+    image.onerror = reject;
+  });
+
 /**
  * Component that renders a Card Item.
  */
-const CardItem = ({
-  url,
-  title,
-  imgSrc,
-  imgAlt,
-  blurb,
-  large,
-  hasAudio,
-  freeform
-}) => {
-  const largeClasses = element =>
-    cx({
-      [element]: true,
-      [`${element}Lg`]: large
-    });
+export default class CardItem extends Component {
+  static propTypes = {
+    url: PropTypes.string,
+    title: PropTypes.string,
+    imgSrc: PropTypes.string,
+    imgAlt: PropTypes.string,
+    blurb: PropTypes.node,
+    large: PropTypes.bool,
+    hasAudio: PropTypes.bool,
+    freeform: PropTypes.bool
+  };
 
-  const freeformClasses = element =>
-    cx({
-      [element]: freeform
-    });
+  static defaultProps = {
+    imgSrc: null,
+    imgAlt: null,
+    blurb: null,
+    url: null,
+    title: null,
+    large: false,
+    hasAudio: false,
+    freeform: false
+  };
 
-  return (
-    <article
-      className={largeClasses('cardItem')}
-      typeof="sioc:Item foaf:Document"
-    >
-      <div className={largeClasses('titleWrap')}>
-        {title && (
-          <h2
-            className={`${!large ? styles.title : ''} ${freeformClasses(
-              'freeformTitle'
-            )}`}
-          >
-            <LinkedItem
-              url={url}
-              className={`${styles.link} ${freeformClasses('freeformLink')}`}
+  loadImage = image => {
+    if (image.isIntersecting) {
+      const img = image.target;
+      const src = img.dataset.src; // eslint-disable-line
+      fetchImage(src).then(() => {
+        img.src = src;
+        img.removeAttribute('data-src');
+      });
+    }
+  };
+
+  render() {
+    const {
+      url,
+      title,
+      imgSrc,
+      imgAlt,
+      blurb,
+      large,
+      hasAudio,
+      freeform
+    } = this.props;
+    const largeClasses = element =>
+      cx({
+        [element]: true,
+        [`${element}Lg`]: large
+      });
+
+    const freeformClasses = element =>
+      cx({
+        [element]: freeform
+      });
+
+    return (
+      <article
+        className={largeClasses('cardItem')}
+        typeof="sioc:Item foaf:Document"
+      >
+        <div className={largeClasses('titleWrap')}>
+          {title && (
+            <h2
+              className={`${!large ? styles.title : ''} ${freeformClasses(
+                'freeformTitle'
+              )}`}
             >
-              {title}
+              <LinkedItem
+                url={url}
+                className={`${styles.link} ${freeformClasses('freeformLink')}`}
+              >
+                {title}
+              </LinkedItem>
+            </h2>
+          )}
+          {title && <span property="dc:title" content={title} />}
+          <span
+            property="sioc:num_replies"
+            content="0"
+            datatype="xsd:integer"
+          />
+        </div>
+        {imgSrc && (
+          <figure className={largeClasses('image')}>
+            <LinkedItem url={url}>
+              <Observer
+                onChange={this.loadImage}
+                onlyOnce
+                rootMargin="0% 0% 25%"
+              >
+                <img
+                  typeof="foaf:Image"
+                  data-src={imgSrc}
+                  alt={imgAlt}
+                  className={largeClasses('img')}
+                />
+              </Observer>
             </LinkedItem>
-          </h2>
+          </figure>
         )}
-        {title && <span property="dc:title" content={title} />}
-        <span property="sioc:num_replies" content="0" datatype="xsd:integer" />
-      </div>
-      {imgSrc && (
-        <figure className={largeClasses('image')}>
-          <LinkedItem url={url}>
-            <img
-              typeof="foaf:Image"
-              src={imgSrc}
-              alt={imgAlt}
-              className={largeClasses('img')}
-            />
-          </LinkedItem>
-        </figure>
-      )}
-      <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
-        {blurb ? <div dangerouslySetInnerHTML={{ __html: blurb }} /> : null}
-        {hasAudio && (
-          <a className={styles.iconLink} href={url}>
-            <Icon
-              name="volume"
-              className={styles.icon}
-              isRoundIcon
-              ariaLabel="Audio"
-            />
-          </a>
-        )}
-      </BlurbContent>
-    </article>
-  );
-};
-
-CardItem.propTypes = {
-  url: PropTypes.string,
-  title: PropTypes.string,
-  imgSrc: PropTypes.string,
-  imgAlt: PropTypes.string,
-  blurb: PropTypes.node,
-  large: PropTypes.bool,
-  hasAudio: PropTypes.bool,
-  freeform: PropTypes.bool
-};
-
-CardItem.defaultProps = {
-  imgSrc: null,
-  imgAlt: null,
-  blurb: null,
-  url: null,
-  title: null,
-  large: false,
-  hasAudio: false,
-  freeform: false
-};
-
-export default CardItem;
+        <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
+          {blurb ? <div dangerouslySetInnerHTML={{ __html: blurb }} /> : null}
+          {hasAudio && (
+            <a className={styles.iconLink} href={url}>
+              <Icon
+                name="volume"
+                className={styles.icon}
+                isRoundIcon
+                ariaLabel="Audio"
+              />
+            </a>
+          )}
+        </BlurbContent>
+      </article>
+    );
+  }
+}

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -123,7 +123,7 @@ const CardItem = ({
       )}
       <BlurbContent freeform={freeform} className={largeClasses('blurb')}>
         {blurb ? (
-          <div dangerouslySetInnerHTML={{ __html: blurb }} />
+          <span dangerouslySetInnerHTML={{ __html: blurb }} />
         ) : null /* eslint-disable-line */}
         {hasAudio && (
           <a className={styles.iconLink} href={url}>

--- a/src/components/Molecules/CardItem/CardItem.test.js
+++ b/src/components/Molecules/CardItem/CardItem.test.js
@@ -8,6 +8,8 @@ import renderer from 'react-test-renderer';
 
 import CardItem from './CardItem.component';
 
+jest.mock('intersection-observer');
+
 describe('<CardItem />', () => {
   it('Matches the Card Item Default snapshot', () => {
     const component = renderer

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -38,7 +38,7 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
       <img
         alt="Placeholder Image"
         className="img"
-        src="http://placehold.it/1920x1080.png"
+        data-src="http://placehold.it/1920x1080.png"
         typeof="foaf:Image"
       />
     </a>
@@ -46,7 +46,7 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
   <p
     className="blurb"
   >
-    <div
+    <span
       dangerouslySetInnerHTML={
         Object {
           "__html": "Test Teaser",
@@ -120,7 +120,7 @@ exports[`<CardItem /> Matches the Card Item No Link  snapshot 1`] = `
     <img
       alt={null}
       className="img"
-      src="http://placehold.it/1920x1080.png"
+      data-src="http://placehold.it/1920x1080.png"
       typeof="foaf:Image"
     />
   </figure>

--- a/src/components/Molecules/Hero/Hero.component.js
+++ b/src/components/Molecules/Hero/Hero.component.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import styles from './Hero.css';
 
 import Icon from '../../Atoms/Svg/Icons.component';
+import LazyLoad from '../../Atoms/LazyLoad/LazyLoad.component';
 
 const Hero = ({
   title,
@@ -21,7 +22,9 @@ const Hero = ({
 }) => (
   <article typeof="sioc:Item foaf:Document" className={styles.hero}>
     <figure className={styles.figure}>
-      <img className={styles.img} src={imgSrc} alt={imgAlt} />
+      <LazyLoad>
+        <img className={styles.img} data-src={imgSrc} alt={imgAlt} />
+      </LazyLoad>
     </figure>
     <div className={styles.text}>
       {hasAudio && (

--- a/src/components/Molecules/Hero/Hero.test.js
+++ b/src/components/Molecules/Hero/Hero.test.js
@@ -8,6 +8,8 @@ import renderer from 'react-test-renderer';
 
 import Hero from './Hero.component';
 
+jest.mock('intersection-observer');
+
 describe('<Hero />', () => {
   it('Matches the Hero snapshot', () => {
     const component = renderer

--- a/src/components/Molecules/Hero/__snapshots__/Hero.test.js.snap
+++ b/src/components/Molecules/Hero/__snapshots__/Hero.test.js.snap
@@ -11,7 +11,7 @@ exports[`<Hero /> Matches the Hero snapshot 1`] = `
     <img
       alt="Opioid Addiction"
       className="img"
-      src="https://media.pri.org/s3fs-public/styles/feature_large/public/story/images/JL1_8064.JPG?itok=WfGYKL2U"
+      data-src="https://media.pri.org/s3fs-public/styles/feature_large/public/story/images/JL1_8064.JPG?itok=WfGYKL2U"
     />
   </figure>
   <div

--- a/src/components/Pages/Home/Home.test.js
+++ b/src/components/Pages/Home/Home.test.js
@@ -8,6 +8,8 @@ import renderer from 'react-test-renderer';
 
 import Home from './Home.component';
 
+jest.mock('intersection-observer');
+
 describe('<Home />', () => {
   it('Matches the Header snapshot', () => {
     const component = renderer.create(<Home />).toJSON();

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -2558,6 +2558,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             >
               <svg
                 aria-hidden={null}
+                aria-label="Audio"
                 aria-labelledby={null}
                 className="svg icon roundIcon"
                 fill="currentcolor"
@@ -2585,7 +2586,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             href="#"
           >
             <img
-              alt="PRIs The World"
+              alt=""
               className="logo"
               src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
             />
@@ -2639,7 +2640,13 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb blurbLg"
           >
-            Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food.
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food.",
+                }
+              }
+            />
             <a
               className="iconLink"
               href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
@@ -2707,7 +2714,13 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. 
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. ",
+                }
+              }
+            />
           </p>
         </article>
       </section>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1452,7 +1452,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       <img
         alt="Opioid Addiction"
         className="img"
-        src="https://media.pri.org/s3fs-public/styles/feature_large/public/story/images/JL1_8064.JPG?itok=WfGYKL2U"
+        data-src="https://media.pri.org/s3fs-public/styles/feature_large/public/story/images/JL1_8064.JPG?itok=WfGYKL2U"
       />
     </figure>
     <div
@@ -1562,7 +1562,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img imgLg"
-                src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
                 typeof="foaf:Image"
               />
             </a>
@@ -1570,7 +1570,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb blurbLg"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food.",
@@ -1636,7 +1636,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
                 typeof="foaf:Image"
               />
             </a>
@@ -1644,7 +1644,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. ",
@@ -1690,7 +1690,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
                 typeof="foaf:Image"
               />
             </a>
@@ -1698,7 +1698,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. ",
@@ -1764,7 +1764,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
                 typeof="foaf:Image"
               />
             </a>
@@ -1772,7 +1772,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Charges against a jailed cartoonist from Equatorial Guinea have been dropped, so why is he still in jail?",
@@ -1809,14 +1809,14 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
             <img
               alt="Alt Text"
               className="img"
-              src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
+              data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
               typeof="foaf:Image"
             />
           </figure>
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'",
@@ -2429,7 +2429,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img imgLg"
-                src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/RTS1M7QU%20(1).jpg?itok=SCBMIFU_"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/RTS1M7QU%20(1).jpg?itok=SCBMIFU_"
                 typeof="foaf:Image"
               />
             </a>
@@ -2437,7 +2437,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb blurbLg"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Little more than a month ago, no one had heard of Macerata. Then the murder of Pamela Mastropietro thrust the small town in central Italy onto the national stage, and the whole course of a pivotal national election was altered.",
@@ -2483,7 +2483,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/fem.jpg?itok=GvblSbSw"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/fem.jpg?itok=GvblSbSw"
                 typeof="foaf:Image"
               />
             </a>
@@ -2491,7 +2491,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "No estamos todas is an Instagram project dedicated to visualizing the issue of femicide in Mexico with original illustrations.",
@@ -2537,7 +2537,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/IliaCalderon_david001.jpg?itok=Be7CbPFn"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/IliaCalderon_david001.jpg?itok=Be7CbPFn"
                 typeof="foaf:Image"
               />
             </a>
@@ -2545,7 +2545,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Ilia Calderón doesn't back down in an interview. And she's determined to allow people growing up like she did see their own experience in her stories.",
@@ -2632,7 +2632,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img imgLg"
-                src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
                 typeof="foaf:Image"
               />
             </a>
@@ -2640,7 +2640,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb blurbLg"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food.",
@@ -2706,7 +2706,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
                 typeof="foaf:Image"
               />
             </a>
@@ -2714,7 +2714,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           <p
             className="blurb"
           >
-            <div
+            <span
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. ",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,7 +1700,7 @@ babel-plugin-transform-undefined-to-void@^6.8.3:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.0.tgz#eb5db0554caffe9ded0206468ec0c6c3b332b9d2"
 
-babel-polyfill@6.26.0:
+babel-polyfill@6.26.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,13 @@
     lodash "^4.17.4"
     url-template "^2.0.8"
 
+"@researchgate/react-intersection-observer@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@researchgate/react-intersection-observer/-/react-intersection-observer-0.6.0.tgz#505f20b62c8941a035442b61ac448870afb5d8a2"
+  dependencies:
+    invariant "^2.2.2"
+    prop-types "^15.6.0"
+
 "@semantic-release/commit-analyzer@^5.0.0":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.2.tgz#4db92f1aaed02397393ac78309892627c88eb64a"
@@ -4738,6 +4745,10 @@ inquirer@^3.0.6:
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+
+intersection-observer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.0.tgz#9fe8bee3953c755b1485c38efd9633d535775ea6"
 
 into-stream@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## [PRIAPI-153: Lazy Loading](https://fourkitchens.atlassian.net/browse/PRIAPI-153)

**This PR does the following:**
- Adds lazy loading component to be used to wrap any direct descendent with the `src` attribute
- Adds lazy loading for images in card item, hero components

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start` and visit the [homepage](http://localhost:9001/?selectedKind=Pages%2FHome&selectedStory=Default&full=1&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) to verify lazy loading is working and experience is solid.
