### PR TITLE
HOTFIX: Update load under title style to match live changes

### DIFF
--- a/src/components/Molecules/CtaMessage/CtaMessage.component.js
+++ b/src/components/Molecules/CtaMessage/CtaMessage.component.js
@@ -73,7 +73,7 @@ export default class CtaMessage extends Component {
         };
 
     return (
-      <div className={promptClass}>
+      <aside className={promptClass}>
         <button className={styles.close} onClick={this.handleDismissClick}>
           <Icon name="cross" width={18} height={18} ariaLabel="Close" />
         </button>
@@ -112,7 +112,7 @@ export default class CtaMessage extends Component {
             </div>
           )}
         </div>
-      </div>
+      </aside>
     );
   }
 }

--- a/src/components/Molecules/CtaMessage/CtaMessage.css
+++ b/src/components/Molecules/CtaMessage/CtaMessage.css
@@ -65,6 +65,7 @@
   margin-bottom: 1rem;
   color: inherit;
   font-size: 1.5rem;
+  font-weight: 900;
 }
 
 .description {
@@ -86,7 +87,7 @@
 }
 
 .loadUnder .title {
-  font-size: 1rem;
+  font-size: 1.1rem;
 }
 
 .loadUnder .close {

--- a/src/components/Molecules/CtaMessage/__snapshots__/CtaMessage.test.js.snap
+++ b/src/components/Molecules/CtaMessage/__snapshots__/CtaMessage.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CtaMessage /> Matches the CTA Message Action button snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -39,11 +39,11 @@ exports[`<CtaMessage /> Matches the CTA Message Action button snapshot 1`] = `
       </a>
     </div>
   </div>
-</div>
+</aside>
 `;
 
 exports[`<CtaMessage /> Matches the CTA Message Blue Action button snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -81,11 +81,11 @@ exports[`<CtaMessage /> Matches the CTA Message Blue Action button snapshot 1`] 
       </a>
     </div>
   </div>
-</div>
+</aside>
 `;
 
 exports[`<CtaMessage /> Matches the CTA Message Decription snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -117,11 +117,11 @@ exports[`<CtaMessage /> Matches the CTA Message Decription snapshot 1`] = `
       Test description
     </p>
   </div>
-</div>
+</aside>
 `;
 
 exports[`<CtaMessage /> Matches the CTA Message Default snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -147,11 +147,11 @@ exports[`<CtaMessage /> Matches the CTA Message Default snapshot 1`] = `
   <div
     className="content"
   />
-</div>
+</aside>
 `;
 
 exports[`<CtaMessage /> Matches the CTA Message Dismiss button snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -199,11 +199,11 @@ exports[`<CtaMessage /> Matches the CTA Message Dismiss button snapshot 1`] = `
       </button>
     </div>
   </div>
-</div>
+</aside>
 `;
 
 exports[`<CtaMessage /> Matches the CTA Message Logo snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -259,11 +259,11 @@ exports[`<CtaMessage /> Matches the CTA Message Logo snapshot 1`] = `
       </svg>
     </div>
   </div>
-</div>
+</aside>
 `;
 
 exports[`<CtaMessage /> Matches the CTA Message Title snapshot 1`] = `
-<div
+<aside
   className="pushDown"
 >
   <button
@@ -295,5 +295,5 @@ exports[`<CtaMessage /> Matches the CTA Message Title snapshot 1`] = `
       Test Title
     </h3>
   </div>
-</div>
+</aside>
 `;


### PR DESCRIPTION
**This PR does the following:**
- Updates load under title styling to match live
- Changes CTA message wrapper element to `<aside>` so its `<h3>` title has its own outline context

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Load under title font weight and size should match live.
