### PR TITLE
PRISB-266: Update to support custom headers with optional link

### DIFF
--- a/src/components/Organisms/CardList/CardList.component.js
+++ b/src/components/Organisms/CardList/CardList.component.js
@@ -5,39 +5,60 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 import styles from './CardList.css';
 
 import Section from '../Content/Section.component';
 
+const cx = classNames.bind(styles);
+
 /**
  * Component that renders a Card List.
  */
-const CardList = ({ category, children, url, src, categoryDescription }) => (
-  <Section className={`${styles.list} ${styles[category]}`}>
-    <header className={styles.header}>
-      <a href={url} className={styles.logoLink}>
-        {src && <img src={src} alt="" className={styles.logo} />}
-        <span>{categoryDescription}</span>
-      </a>
-    </header>
-    {children}
-  </Section>
-);
+const CardList = ({ name, id, children, url, logo, title }) => {
+  const cardClasses = cx({
+    list: true,
+    [name]: styles[name]
+  });
+
+  const headerContent = (
+    <React.Fragment>
+      {logo && <img src={logo} alt="" className={styles.logo} />}
+      {title}
+    </React.Fragment>
+  );
+
+  return (
+    <Section className={cardClasses}>
+      <header id={id} className={styles.header}>
+        {(url && (
+          <a href={url} className={styles.logoLink}>
+            {headerContent}
+          </a>
+        )) ||
+          headerContent}
+      </header>
+      {children}
+    </Section>
+  );
+};
 
 CardList.propTypes = {
-  category: PropTypes.string,
+  name: PropTypes.string,
+  id: PropTypes.string,
   children: PropTypes.node,
   url: PropTypes.string,
-  src: PropTypes.string,
-  categoryDescription: PropTypes.string
+  logo: PropTypes.string,
+  title: PropTypes.string
 };
 
 CardList.defaultProps = {
-  category: 'world',
+  name: null,
+  id: null,
   children: [],
   url: null,
-  src: null,
-  categoryDescription: null
+  logo: null,
+  title: null
 };
 
 export default CardList;

--- a/src/components/Organisms/CardList/CardList.component.js
+++ b/src/components/Organisms/CardList/CardList.component.js
@@ -8,8 +8,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './CardList.css';
 
-import Section from '../Content/Section.component';
-
 const cx = classNames.bind(styles);
 
 /**
@@ -29,17 +27,19 @@ const CardList = ({ name, id, children, url, logo, title }) => {
   );
 
   return (
-    <Section className={cardClasses}>
-      <header id={id} className={styles.header}>
-        {(url && (
-          <a href={url} className={styles.logoLink}>
-            {headerContent}
-          </a>
-        )) ||
-          headerContent}
-      </header>
+    <section id={id} className={cardClasses}>
+      {title && (
+        <header className={styles.header}>
+          {(url && (
+            <a href={url} className={styles.logoLink}>
+              {headerContent}
+            </a>
+          )) ||
+            headerContent}
+        </header>
+      )}
       {children}
-    </Section>
+    </section>
   );
 };
 

--- a/src/components/Organisms/CardList/CardList.css
+++ b/src/components/Organisms/CardList/CardList.css
@@ -18,6 +18,26 @@
   margin-bottom: 0;
 }
 
+.header {
+  border-bottom: 1px solid grayLighter;
+  padding: 0.5rem 1rem 0.7rem;
+  font-family: heading;
+  font-weight: bold;
+  line-height: 50px;
+}
+
+.logoLink {
+  align-items: center;
+  text-decoration: none;
+}
+
+.logo {
+  float: left;
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+}
+
 .america-abroad {
   border-top-color: americaAbroad;
 }
@@ -92,25 +112,4 @@
 
 .livable-planet {
   border-top-color: livablePlanet;
-}
-
-.header {
-  border-bottom: 1px solid grayLighter;
-  padding: 0.5rem 1rem 0.7rem;
-  font-family: heading;
-}
-
-.logoLink {
-  align-items: center;
-  color: blue;
-  display: flex;
-  font-weight: bold;
-  min-height: 50px;
-  text-decoration: none;
-}
-
-.logo {
-  display: block;
-  margin-right: 10px;
-  width: 50px;
 }

--- a/src/components/Organisms/CardList/__snapshots__/CardList.test.js.snap
+++ b/src/components/Organisms/CardList/__snapshots__/CardList.test.js.snap
@@ -2,24 +2,16 @@
 
 exports[`<CardList /> Matches the Card List snapshot 1`] = `
 <section
-  className="className && list world"
+  className="className && list null"
 >
   <header
     className="header"
+    id={null}
   >
     <a
       className="logoLink"
       href="#"
-    >
-      <img
-        alt=""
-        className="logo"
-        src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
-      />
-      <span>
-        PRIs The World
-      </span>
-    </a>
+    />
   </header>
   <span>
     One

--- a/src/components/Organisms/CardList/__snapshots__/CardList.test.js.snap
+++ b/src/components/Organisms/CardList/__snapshots__/CardList.test.js.snap
@@ -2,17 +2,9 @@
 
 exports[`<CardList /> Matches the Card List snapshot 1`] = `
 <section
-  className="className && list null"
+  className="list null"
+  id={null}
 >
-  <header
-    className="header"
-    id={null}
-  >
-    <a
-      className="logoLink"
-      href="#"
-    />
-  </header>
   <span>
     One
   </span>

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -26,10 +26,10 @@ storiesOf('Organisms/CardList', module)
   .addDecorator(checkA11y)
   .add('Card List with Image', () => (
     <CardList
-      src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
-      category="pris-the-world"
+      logo="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
+      name="pris-the-world"
       url="#"
-      categoryDescription="PRIs The World"
+      title="PRI's The World"
     >
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
@@ -75,11 +75,38 @@ storiesOf('Organisms/CardList', module)
 storiesOf('Organisms/CardList', module)
   .addDecorator(checkA11y)
   .add('Without Image', () => (
-    <CardList
-      category="pris-the-world"
-      url="#"
-      categoryDescription="PRIs The World"
-    >
+    <CardList name="pris-the-world" url="#" title="PRI's The World">
+      <CardItem
+        title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgAlt="Alt Text"
+        blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
+        large
+        hasAudio
+      />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+      />
+      <CardItem
+        title="Progressives in Congress side with Trump on trade"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
+        imgAlt="Alt Text"
+        blurb="NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. "
+        hasAudio
+      />
+    </CardList>
+  ));
+
+storiesOf('Organisms/CardList', module)
+  .addDecorator(checkA11y)
+  .add('Without URL', () => (
+    <CardList name="custom-header" title="Custom Header">
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
         url="stories/2017-07-24/clearing-mines-and-explosives-mosul"

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -28,6 +28,7 @@ storiesOf('Organisms/CardList', module)
     <CardList
       logo="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
       name="pris-the-world"
+      id="program-with-logo"
       url="#"
       title="PRI's The World"
     >
@@ -107,6 +108,37 @@ storiesOf('Organisms/CardList', module)
   .addDecorator(checkA11y)
   .add('Without URL', () => (
     <CardList name="custom-header" title="Custom Header">
+      <CardItem
+        title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgAlt="Alt Text"
+        blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
+        large
+        hasAudio
+      />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+      />
+      <CardItem
+        title="Progressives in Congress side with Trump on trade"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
+        imgAlt="Alt Text"
+        blurb="NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. "
+        hasAudio
+      />
+    </CardList>
+  ));
+
+storiesOf('Organisms/CardList', module)
+  .addDecorator(checkA11y)
+  .add('Without Header', () => (
+    <CardList name="no-header">
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
         url="stories/2017-07-24/clearing-mines-and-explosives-mosul"

--- a/src/components/Pages/Home/Home.component.js
+++ b/src/components/Pages/Home/Home.component.js
@@ -47,10 +47,11 @@ const Home = ({ baseUrl }) => (
     <LayoutMain>
       <LayoutMainList>
         <CardList
-          src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
-          category="pris-the-world"
+          logo="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
+          name="pris-the-world"
+          id="card-top"
           url="#"
-          categoryDescription="PRIs The World"
+          title="PRIs The World"
         >
           <CardItem
             title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
@@ -263,10 +264,11 @@ const Home = ({ baseUrl }) => (
       </LayoutAsideCallouts>
       <LayoutMainList2>
         <CardList
-          src="https://media.pri.org/s3fs-public/styles/medium_square/public/logo_gp.png"
-          category="pris-globalpost"
+          logo="https://media.pri.org/s3fs-public/styles/medium_square/public/logo_gp.png"
+          name="globalpost"
+          id="card-1"
           url="#"
-          categoryDescription="GlobalPost"
+          title="GlobalPost"
         >
           <CardItem
             title="How the murder of a young woman turned Italy's elections into a referendum on immigration"
@@ -293,10 +295,9 @@ const Home = ({ baseUrl }) => (
           />
         </CardList>
         <CardList
-          src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
-          category="pris-the-world"
-          url="#"
-          categoryDescription="PRIs The World"
+          name="custom-card-header"
+          id="card-2"
+          title="Custom Card Header"
         >
           <CardItem
             title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1506,11 +1506,11 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       className="className && mainList"
     >
       <section
-        className="className && list pris-the-world"
+        className="list pris-the-world"
+        id="card-top"
       >
         <header
           className="header"
-          id="card-top"
         >
           <a
             className="logoLink"
@@ -2382,11 +2382,11 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       className="className && mainList2"
     >
       <section
-        className="className && list globalpost"
+        className="list globalpost"
+        id="card-1"
       >
         <header
           className="header"
-          id="card-1"
         >
           <a
             className="logoLink"
@@ -2584,11 +2584,11 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
         </article>
       </section>
       <section
-        className="className && list custom-card-header"
+        className="list custom-card-header"
+        id="card-2"
       >
         <header
           className="header"
-          id="card-2"
         >
           Custom Card Header
         </header>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1510,6 +1510,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       >
         <header
           className="header"
+          id="card-top"
         >
           <a
             className="logoLink"
@@ -1520,9 +1521,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               className="logo"
               src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
             />
-            <span>
-              PRIs The World
-            </span>
+            PRIs The World
           </a>
         </header>
         <article
@@ -2383,10 +2382,11 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       className="className && mainList2"
     >
       <section
-        className="className && list pris-globalpost"
+        className="className && list globalpost"
       >
         <header
           className="header"
+          id="card-1"
         >
           <a
             className="logoLink"
@@ -2397,9 +2397,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               className="logo"
               src="https://media.pri.org/s3fs-public/styles/medium_square/public/logo_gp.png"
             />
-            <span>
-              GlobalPost
-            </span>
+            GlobalPost
           </a>
         </header>
         <article
@@ -2586,24 +2584,13 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
         </article>
       </section>
       <section
-        className="className && list pris-the-world"
+        className="className && list custom-card-header"
       >
         <header
           className="header"
+          id="card-2"
         >
-          <a
-            className="logoLink"
-            href="#"
-          >
-            <img
-              alt=""
-              className="logo"
-              src="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
-            />
-            <span>
-              PRIs The World
-            </span>
-          </a>
+          Custom Card Header
         </header>
         <article
           className="cardItem cardItemLg"


### PR DESCRIPTION
## [PRISB-266: Update CardList to support homepage card header changes](https://fourkitchens.atlassian.net/browse/PRISB-266)

**This PR does the following:**
- add support for header without a link
- doesn't render header if title is not set
- refactor CardList props to not have a category-centric nomenclature
- refactor CardList header to not depend on a flexbox link wrapper
- add `id` prop to CardList
- update organism and Home component to make use of prop changes

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Look at __Organisms > CardList__ and __Pages > Home__ stories.
