### PR TITLE
PRISB-283: GDRP cookie disclaimer messages require links to policy pages.

### DIFF
--- a/src/components/Molecules/CtaMessage/CtaMessage.component.js
+++ b/src/components/Molecules/CtaMessage/CtaMessage.component.js
@@ -89,7 +89,13 @@ export default class CtaMessage extends Component {
             </div>
           )}
           {title && <h3 className={styles.title}>{title}</h3>}
-          {description && <p className={styles.description}>{description}</p>}
+          {description ? (
+            /* eslint-disable-next-line */
+            <div
+              className={styles.description}
+              dangerouslySetInnerHTML={{ __html: description }}
+            />
+          ) : null}
           {action && (
             <div className={styles.actions}>
               <ButtonLink

--- a/src/components/Molecules/CtaMessage/CtaMessage.component.js
+++ b/src/components/Molecules/CtaMessage/CtaMessage.component.js
@@ -90,9 +90,9 @@ export default class CtaMessage extends Component {
           )}
           {title && <h3 className={styles.title}>{title}</h3>}
           {description ? (
-            /* eslint-disable-next-line */
             <div
               className={styles.description}
+              /* eslint-disable-next-line */
               dangerouslySetInnerHTML={{ __html: description }}
             />
           ) : null}

--- a/src/components/Molecules/CtaMessage/CtaMessage.css
+++ b/src/components/Molecules/CtaMessage/CtaMessage.css
@@ -1,6 +1,6 @@
 /* import colors... */
 @value colors: "../../00_global/colors.css";
-@value gray, orange, grayLighter from colors;
+@value gray, orange, white, grayLighter from colors;
 
 /* import breakpoints */
 @value medium as bp-medium from "../../00_global/breakpoints.css";
@@ -75,6 +75,17 @@
 .description {
   font-size: 1.1rem;
   line-height: 1.4rem;
+}
+
+.description a {
+  color: white;
+  border-bottom: 1px dotted currentColor;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.description a:hover {
+  border-bottom: none;
 }
 
 .actions * + * {

--- a/src/components/Molecules/CtaMessage/__snapshots__/CtaMessage.test.js.snap
+++ b/src/components/Molecules/CtaMessage/__snapshots__/CtaMessage.test.js.snap
@@ -111,11 +111,14 @@ exports[`<CtaMessage /> Matches the CTA Message Decription snapshot 1`] = `
   <div
     className="content"
   >
-    <p
+    <div
       className="description"
-    >
-      Test description
-    </p>
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Test description",
+        }
+      }
+    />
   </div>
 </aside>
 `;

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -145,7 +145,7 @@ storiesOf('Molecules/CtaMessage', module)
       onClose={action('close-prompt')}
       type="loadUnder"
       title="Google is the #1 search engine."
-      description="Don't believe us? Google it."
+      description={`Don't believe us? <a href="http://www.google.com/" target="_blank">Google it.</a>`}
       action={{
         label: 'Google It',
         btnColor: 'Blue',

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -2905,11 +2905,14 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       >
         Google is the #1 search engine.
       </h3>
-      <p
+      <div
         className="description"
-      >
-        Don't believe us? Google it.
-      </p>
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Don't believe us? Google it.",
+          }
+        }
+      />
       <div
         className="actions"
       >


### PR DESCRIPTION
## [PRISB-283: GDPR: Add cookie disclaimer message](https://fourkitchens.atlassian.net/browse/PRISB-283)

**This PR does the following:**
- Allows CTA message descriptions to contain HTML markup.

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Got to [Molecules > CtaMessage > Load Under](http://localhost:9001/?selectedKind=Molecules%2FCtaMessage&selectedStory=Load%20Under&full=0&addons=1&stories=1&panelRight=1&addonPanel=%40storybook%2Faddon-a11y%2Fpanel)
- [x] Ensure link appears in description and it is functional.
