### PR TITLE
fix(ctamessage): render dismiss button when action note defined

### DIFF
--- a/src/components/Molecules/CtaMessage/CtaMessage.component.js
+++ b/src/components/Molecules/CtaMessage/CtaMessage.component.js
@@ -96,16 +96,18 @@ export default class CtaMessage extends Component {
               dangerouslySetInnerHTML={{ __html: description }}
             />
           ) : null}
-          {action && (
+          {(action || dismiss) && (
             <div className={styles.actions}>
-              <ButtonLink
-                className={styles.actionBtn}
-                url={action.url}
-                color={action.btnColor}
-                onClick={this.handleActionClick}
-              >
-                {action.label}
-              </ButtonLink>
+              {action && (
+                <ButtonLink
+                  className={styles.actionBtn}
+                  url={action.url}
+                  color={action.btnColor}
+                  onClick={this.handleActionClick}
+                >
+                  {action.label}
+                </ButtonLink>
+              )}
               {dismiss && (
                 <Button
                   className={styles.dismissBtn}


### PR DESCRIPTION
**This PR does the following:**
- Renders dismiss button when action button is not defined. Useful for informative messages such as cookie notices.

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Go to Molecules > CtaMessage > Load Under.
- [x] Ensure message renders.
