### PR TITLE
HOTFIX: CTA Message action url is optional

### DIFF
--- a/src/components/Molecules/CtaMessage/CtaMessage.component.js
+++ b/src/components/Molecules/CtaMessage/CtaMessage.component.js
@@ -30,7 +30,7 @@ export default class CtaMessage extends Component {
     action: PropTypes.shape({
       label: PropTypes.string.isRequired,
       btnColor: ButtonLink.propTypes.color,
-      url: PropTypes.string.isRequired
+      url: PropTypes.string
     }),
     dismiss: PropTypes.shape({
       label: PropTypes.string.isRequired

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -157,6 +157,24 @@ storiesOf('Molecules/CtaMessage', module)
     />
   ));
 
+storiesOf('Molecules/CtaMessage', module)
+  .addDecorator(checkA11y)
+  .add('Load Under (No Action URL)', () => (
+    <CtaMessage
+      onClose={action('close-prompt')}
+      type="loadUnder"
+      title="Google is the #1 search engine."
+      description={`Don't believe us? <a href="http://www.google.com/" target="_blank">Google it.</a>`}
+      action={{
+        label: 'Google It',
+        btnColor: 'Orange'
+      }}
+      dismiss={{
+        label: 'Yey, I know'
+      }}
+    />
+  ));
+
 /**
  * Add storybook definition for Hero.
  */


### PR DESCRIPTION
**This PR does the following:**
- CTA Message actions do not require a URL.

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Go to Molecules > CtaMessage > Load Under (No Action URL)
- [ ] Ensure message has an orange button that doesn't navigate away when clicked.
- [ ] Check dev console to see that click events were fired.
