### PR TITLE
PRISB-295: add Quick Link colors for Takeaway and LOE

### DIFF
--- a/src/components/00_global/colors.css
+++ b/src/components/00_global/colors.css
@@ -21,7 +21,7 @@
 @value world: #00a0de;
 @value americaAbroad: #235e7c;
 @value bostonCalling: world;
-@value globalPost: #ce2427;
+@value globalPost: #5179bc;
 @value liveWire: #cd212c;
 @value livingEarth: #310133;
 @value otherhood: #70200a;
@@ -29,7 +29,7 @@
 @value scienceHappiness: yellow;
 @value sciFri: #f0502d;
 @value studio: #ed1b24;
-@value takeaway: #eb022d;
+@value takeaway: #ed5b4b;
 @value thingsBoom: #da2835;
 @value undiscovered: #0096d4;
 @value worldWords: world;

--- a/src/components/Molecules/List/List.css
+++ b/src/components/Molecules/List/List.css
@@ -1,6 +1,6 @@
 /* import colors... */
 @value colors: "../../00_global/colors.css";
-@value grayLight, orange, world, studio, globalPost, acrossWomensLives, globalNation, globalSecurity, livablePlanet from colors;
+@value grayLight, orange, world, studio, globalPost, acrossWomensLives, globalNation, globalSecurity, livablePlanet, takeaway, livingEarth from colors;
 
 .list {
   margin: 6px 0;
@@ -89,4 +89,20 @@ a.livablePlanet {
 
 a.livablePlanet:hover {
   background: livablePlanet;
+}
+
+a.livingEarth {
+  border-left-color: livingEarth;
+}
+
+a.livingEarth:hover {
+  background: livingEarth;
+}
+
+a.takeaway {
+  border-left-color: takeaway;
+}
+
+a.takeaway:hover {
+  background: takeaway;
 }

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -242,9 +242,19 @@ storiesOf('Molecules/MenuList', module)
           itemLinkClass: 'studio'
         },
         {
+          name: 'Takeaway',
+          url: `${baseUrl}/programs/takeaway`,
+          itemLinkClass: 'takeaway'
+        },
+        {
           name: 'GlobalPost',
           url: `${baseUrl}/programs/globalpost`,
           itemLinkClass: 'globalPost'
+        },
+        {
+          name: 'Living on Earth',
+          url: `${baseUrl}/programs/living-earth`,
+          itemLinkClass: 'livingEarth'
         },
         {
           name: "Across Women's Lives",


### PR DESCRIPTION
## [PRISB-295: Add Living on Earth to homepage Quick Links](https://fourkitchens.atlassian.net/browse/PRISB-295)

**This PR does the following:**
- Adds Quick Link colors for Living on Earth (LOE) & Takeaway (TT)
- Changes GlobalPost (GP) Quick Link color to Blue (from red, since everything else is red)

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Go [here](http://localhost:9001/?selectedKind=Molecules%2FMenuList&selectedStory=Quick%20Links&full=0&addons=1&stories=1&panelRight=0&addonPanel=%40storybook%2Faddon-a11y%2Fpanel) and confirm that TT color resembles coral (pink/red-ish)
- [x] Confirm that LOE color is a dark purple
- [x] Confirm that GP color is blue
