### PR TITLE
PRISB-303: fix typo in main menu

### DIFF
--- a/src/components/Organisms/Header/MainMenu.component.js
+++ b/src/components/Organisms/Header/MainMenu.component.js
@@ -185,7 +185,7 @@ export default class MainMenu extends Component {
                 url: `${baseUrl}programs/podcast-playlist`
               },
               {
-                name: 'Science of Happiness',
+                name: 'The Science of Happiness',
                 url: `${baseUrl}programs/science-happiness`
               },
               {

--- a/src/components/Organisms/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Organisms/Header/__snapshots__/Header.test.js.snap
@@ -505,7 +505,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
                   className="listLink accordionContentMenuLink accordionContentMenuLinkGreen "
                   href="https://www.pri.org/programs/science-happiness"
                 >
-                  Science of Happiness
+                  The Science of Happiness
                 </a>
               </li>
               <li

--- a/src/components/Organisms/Header/__snapshots__/MainMenu.test.js.snap
+++ b/src/components/Organisms/Header/__snapshots__/MainMenu.test.js.snap
@@ -494,7 +494,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
               className="listLink accordionContentMenuLink accordionContentMenuLinkGreen "
               href="https://www.pri.org/programs/science-happiness"
             >
-              Science of Happiness
+              The Science of Happiness
             </a>
           </li>
           <li

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -506,7 +506,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                     className="listLink accordionContentMenuLink accordionContentMenuLinkGreen "
                     href="https://www.pri.org/programs/science-happiness"
                   >
-                    Science of Happiness
+                    The Science of Happiness
                   </a>
                 </li>
                 <li


### PR DESCRIPTION
## [Fix typo in homepage menu](https://fourkitchens.atlassian.net/browse/PRISB-303)

**This PR does the following:**
- `Science of Happiness` should be `The Science of Happiness`

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Go [here](http://localhost:9001/?selectedKind=Organisms%2FHeader&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel), open the hamburger icon, open podcasts and confirm the menu item says `The Science of Happiness`
