### PR TITLE
Hotfix: Restyle pulldown menu

### DIFF
--- a/src/components/Molecules/CtaMessage/CtaMessage.component.js
+++ b/src/components/Molecules/CtaMessage/CtaMessage.component.js
@@ -19,7 +19,7 @@ const cx = classNames.bind(styles);
  * Component that renders a CTA (Call to action) message.
  */
 export default class CtaMessage extends Component {
-  static messageTypes = ['pushDown', 'loadUnder'];
+  static messageTypes = ['pushDown', 'announcement', 'loadUnder'];
 
   static propTypes = {
     onClose: PropTypes.func,

--- a/src/components/Molecules/CtaMessage/CtaMessage.css
+++ b/src/components/Molecules/CtaMessage/CtaMessage.css
@@ -1,6 +1,6 @@
 /* import colors... */
 @value colors: "../../00_global/colors.css";
-@value gray, orange, white, grayLighter from colors;
+@value gray, orange, white, grayLighter, grayDark from colors;
 
 /* import breakpoints */
 @value medium as bp-medium from "../../00_global/breakpoints.css";
@@ -12,8 +12,8 @@
   display: block;
   position: relative;
   box-sizing: border-box;
-  background-color: grayLighter;
-  color: gray;
+  background-color: gray;
+  color: grayLighter;
   text-align: center;
 }
 
@@ -24,10 +24,16 @@
   white-space: nowrap;
 }
 
+.announcement {
+  @mixin prompt;
+  background-color: grayLighter;
+  color: gray;
+}
+
 .pushDown {
   @mixin prompt;
 
-  // display: none;
+  display: none;
 }
 
 .loadUnder {
@@ -61,7 +67,7 @@
   color: orange;
 }
 
-.content {
+.announcement .content {
   max-width: 800px;
   margin: 0 auto;
   padding: 15px;
@@ -74,20 +80,37 @@
 .title {
   margin-bottom: 1rem;
   color: inherit;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   font-weight: 900;
+}
+
+.announcement .title {
+  font-size: 1.2rem;
   text-align: left;
 }
 
 .description {
+  margin-bottom: 1rem;
   font-size: 1.1rem;
   line-height: 1.4rem;
+}
+
+.announcement .description {
+  display: grid;
+  grid-template-columns: auto minmax(33.33%, 200px);
+  grid-template-areas:
+    'TEXT'
+    'NAV';
   color: grayDark;
   text-align: left;
 }
 
+.announcement .description p,
 .pushDown .description p {
   display: none;
+}
+.announcement .description p {
+  grid-area: TEXT;
 }
 
 .description em,
@@ -105,18 +128,16 @@
   border-bottom: none;
 }
 
-.description ul {
-  margin-bottom: 10px;
+.announcement .description ul {
+  grid-area: NAV;
 }
 
-.description ul li {
+.announcement .description ul li {
   margin-bottom: 5px;
 }
 
-.description img {
-  float: right;
-  max-width: 200px;
-  margin: 0 0 15px 15px;
+.announcement .description img {
+  grid-area: IMAGE;
   display: none;
 }
 
@@ -171,11 +192,20 @@
 }
 
 @media bp-medium {
+  .announcement,
   .pushDown {
     display: block;
     padding: 35px 55px;
   }
 
+  .announcement .description {
+    grid-template-areas:
+      'TEXT IMAGE'
+      'NAV IMAGE';
+  }
+
+  .announcement .description p,
+  .announcement .description img,
   .pushDown .description p,
   .pushDown .description img {
     display: block;
@@ -185,17 +215,13 @@
     font-size: 1.5rem;
   }
 
-  .description ul li {
+  .announcement .description ul li {
     display: inline;
     list-style: none;
   }
 
-  .description ul li:after {
+  .announcement .description ul li + li:before {
     content: ' | ';
-  }
-
-  .description ul li:last-of-type:after {
-    content: '';
   }
 
   .loadUnder .logo {

--- a/src/components/Molecules/CtaMessage/CtaMessage.css
+++ b/src/components/Molecules/CtaMessage/CtaMessage.css
@@ -12,8 +12,8 @@
   display: block;
   position: relative;
   box-sizing: border-box;
-  background-color: gray;
-  color: grayLighter;
+  background-color: grayLighter;
+  color: gray;
   text-align: center;
 }
 
@@ -27,7 +27,7 @@
 .pushDown {
   @mixin prompt;
 
-  display: none;
+  // display: none;
 }
 
 .loadUnder {
@@ -61,6 +61,12 @@
   color: orange;
 }
 
+.content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 15px;
+}
+
 .logo {
   margin-bottom: 1rem;
 }
@@ -70,15 +76,26 @@
   color: inherit;
   font-size: 1.5rem;
   font-weight: 900;
+  text-align: left;
 }
 
 .description {
   font-size: 1.1rem;
   line-height: 1.4rem;
+  color: grayDark;
+  text-align: left;
+}
+
+.pushDown .description p {
+  display: none;
+}
+
+.description em,
+.description i {
+  font-style: italic;
 }
 
 .description a {
-  color: white;
   border-bottom: 1px dotted currentColor;
   font-weight: bold;
   text-decoration: none;
@@ -86,6 +103,25 @@
 
 .description a:hover {
   border-bottom: none;
+}
+
+.description ul {
+  margin-bottom: 10px;
+}
+
+.description ul li {
+  margin-bottom: 5px;
+}
+
+.description img {
+  float: right;
+  max-width: 200px;
+  margin: 0 0 15px 15px;
+  display: none;
+}
+
+.actions {
+  clear: both;
 }
 
 .actions * + * {
@@ -138,6 +174,24 @@
   .pushDown {
     display: block;
     padding: 35px 55px;
+  }
+
+  .pushDown .description p,
+  .pushDown .description img {
+    display: block;
+  }
+
+  .description ul li {
+    display: inline;
+    list-style: none;
+  }
+
+  .description ul li:after {
+    content: ' | ';
+  }
+
+  .description ul li:last-of-type:after {
+    content: '';
   }
 
   .loadUnder .logo {

--- a/src/components/Molecules/CtaMessage/CtaMessage.css
+++ b/src/components/Molecules/CtaMessage/CtaMessage.css
@@ -98,6 +98,7 @@
 .announcement .description {
   display: grid;
   grid-template-columns: auto minmax(33.33%, 200px);
+  grid-column-gap: 0.8rem;
   grid-template-areas:
     'TEXT'
     'NAV';

--- a/src/components/Molecules/CtaMessage/CtaMessage.css
+++ b/src/components/Molecules/CtaMessage/CtaMessage.css
@@ -74,7 +74,7 @@
 .title {
   margin-bottom: 1rem;
   color: inherit;
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   font-weight: 900;
   text-align: left;
 }
@@ -179,6 +179,10 @@
   .pushDown .description p,
   .pushDown .description img {
     display: block;
+  }
+
+  .title {
+    font-size: 1.5rem;
   }
 
   .description ul li {

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -145,8 +145,8 @@ storiesOf('Molecules/CtaMessage', module)
     <CtaMessage
       onClose={action('close-prompt')}
       showLogo
-      title="Google is the #1 search engine."
-      description="Don't believe us? Google it."
+      title="This is the title"
+      description="<img src=&quot;https:/media-pri-dev.s3.amazonaws.com/s3fs-public/styles/card_large/public/images/2018/08/080618-hiroshima-obama-embrace.jpg?itok=UAIeO7ma&quot; alt=&quot;test&quot; /><p>This is a paragraph of text. Note how this can hold HTML tags. Mauris rhoncus malesuada felis sit amet mattis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ac lorem cursus, suscipit ligula quis, mattis metus.</p><ul><li><a href=&quot;#&quot;>List item 1</a></li><li><a href=&quot;#&quot;>List item 2</a></li><li><a href=&quot;#&quot;>List item 3</a></li><li><a href=&quot;#&quot;>List item 4</a></li></ul>"
       action={{
         label: 'Google It',
         btnColor: 'Orange',

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -145,6 +145,26 @@ storiesOf('Molecules/CtaMessage', module)
     <CtaMessage
       onClose={action('close-prompt')}
       showLogo
+      title="Google is the #1 search engine."
+      description="Don't believe us? Google it."
+      action={{
+        label: 'Google It',
+        btnColor: 'Orange',
+        url: 'https://www.google.com/'
+      }}
+      dismiss={{
+        label: 'Yey, I know'
+      }}
+    />
+  ));
+
+storiesOf('Molecules/CtaMessage', module)
+  .addDecorator(checkA11y)
+  .add('Announcement', () => (
+    <CtaMessage
+      onClose={action('close-prompt')}
+      type="announcement"
+      showLogo
       title="This is the title"
       description="<img src=&quot;https:/media-pri-dev.s3.amazonaws.com/s3fs-public/styles/card_large/public/images/2018/08/080618-hiroshima-obama-embrace.jpg?itok=UAIeO7ma&quot; alt=&quot;test&quot; /><p>This is a paragraph of text. Note how this can hold HTML tags. Mauris rhoncus malesuada felis sit amet mattis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ac lorem cursus, suscipit ligula quis, mattis metus.</p><ul><li><a href=&quot;#&quot;>List item 1</a></li><li><a href=&quot;#&quot;>List item 2</a></li><li><a href=&quot;#&quot;>List item 3</a></li><li><a href=&quot;#&quot;>List item 4</a></li></ul>"
       action={{


### PR DESCRIPTION
**This PR does the following:**
- Restyles the pull down banner for an upcoming announcement.
- NOTE: Not all the elements will be in use with the announcement, but they are present in the component.

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Go [here](http://localhost:9001/?selectedKind=Molecules%2FCtaMessage&selectedStory=Push%20Down&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) and ensure that the elements all look in order. 
- [ ] Adjust the viewport for mobile devices. Ensure you only see the title and a `<ul>` element. 
