### PR TITLE
PRISB-416: Remove hasAudio icon

### DIFF
--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './CardItem.css';
 
-import Icon from '../../Atoms/Svg/Icons.component';
 import LazyLoad from '../../Atoms/LazyLoad/LazyLoad.component';
 
 const cx = classNames.bind(styles);
@@ -37,16 +36,7 @@ BlurbContent.defaultProps = {
 /**
  * Component that renders a Card Item.
  */
-const CardItem = ({
-  url,
-  title,
-  imgSrc,
-  imgAlt,
-  blurb,
-  large,
-  hasAudio,
-  freeform
-}) => (
+const CardItem = ({ url, title, imgSrc, imgAlt, blurb, large, freeform }) => (
   <article
     className={cx({
       cardItem: true,
@@ -75,16 +65,6 @@ const CardItem = ({
       <div className={`${styles.titleWrap}`}>
         <h2 className={`${styles.title}`}>
           <a href={url} className={`${styles.link}`}>
-            {hasAudio && (
-              <a className={styles.iconLink} href={url}>
-                <Icon
-                  name="volume"
-                  className={styles.icon}
-                  isRoundIcon
-                  ariaLabel="Audio"
-                />
-              </a>
-            )}
             {title}
           </a>
         </h2>
@@ -108,7 +88,6 @@ CardItem.propTypes = {
   imgAlt: PropTypes.string,
   blurb: PropTypes.node,
   large: PropTypes.bool,
-  hasAudio: PropTypes.bool,
   freeform: PropTypes.bool
 };
 
@@ -119,7 +98,6 @@ CardItem.defaultProps = {
   url: null,
   title: null,
   large: false,
-  hasAudio: false,
   freeform: false
 };
 

--- a/src/components/Molecules/Hero/Hero.component.js
+++ b/src/components/Molecules/Hero/Hero.component.js
@@ -7,13 +7,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './Hero.css';
 
-import Icon from '../../Atoms/Svg/Icons.component';
 import LazyLoad from '../../Atoms/LazyLoad/LazyLoad.component';
 
 const Hero = ({
   title,
   summary,
-  hasAudio,
   category,
   categoryUrl,
   imgSrc,
@@ -27,16 +25,6 @@ const Hero = ({
       </LazyLoad>
     </figure>
     <div className={styles.text}>
-      {hasAudio && (
-        <a className={styles.iconLink} href={url}>
-          <Icon
-            name="volume"
-            className={styles.icon}
-            isRoundIcon
-            ariaLabel="Audio"
-          />
-        </a>
-      )}
       <h2>
         <a className={styles.title} href={url}>
           {title}
@@ -57,12 +45,10 @@ Hero.propTypes = {
   categoryUrl: PropTypes.string,
   imgSrc: PropTypes.string.isRequired,
   imgAlt: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
-  hasAudio: PropTypes.bool
+  url: PropTypes.string.isRequired
 };
 
 Hero.defaultProps = {
-  hasAudio: false,
   categoryUrl: null
 };
 

--- a/src/components/Molecules/Hero/__snapshots__/Hero.test.js.snap
+++ b/src/components/Molecules/Hero/__snapshots__/Hero.test.js.snap
@@ -17,26 +17,6 @@ exports[`<Hero /> Matches the Hero snapshot 1`] = `
   <div
     className="text"
   >
-    <a
-      className="iconLink"
-      href="https://google.com"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Audio"
-        aria-labelledby={null}
-        className="svg icon roundIcon"
-        fill="currentcolor"
-        height={28}
-        version={1.1}
-        viewBox="0 0 28 28"
-        width={28}
-      >
-        <path
-          d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-        />
-      </svg>
-    </a>
     <h2>
       <a
         className="title"
@@ -77,26 +57,6 @@ exports[`<Hero /> Matches the Hero snapshot with category url 1`] = `
   <div
     className="text"
   >
-    <a
-      className="iconLink"
-      href="https://google.com"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Audio"
-        aria-labelledby={null}
-        className="svg icon roundIcon"
-        fill="currentcolor"
-        height={28}
-        version={1.1}
-        viewBox="0 0 28 28"
-        width={28}
-      >
-        <path
-          d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-        />
-      </svg>
-    </a>
     <h2>
       <a
         className="title"

--- a/src/components/Molecules/Teaser/TeaserItem.component.js
+++ b/src/components/Molecules/Teaser/TeaserItem.component.js
@@ -7,17 +7,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './TeaserItem.css';
 
-import Icon from '../../Atoms/Svg/Icons.component';
-
 /**
  * Component that renders an Article Item.
  */
-const TeaserItem = ({ title, url, programTitle, programUrl, hasAudio }) => (
+const TeaserItem = ({ title, url, programTitle, programUrl }) => (
   <article className={styles.teaserItem} typeof="sioc:Item foaf:Document">
     <div className={styles.titleWrap}>
       <h4 className={styles.title}>
         <a className={styles.link} href={url}>
-          {hasAudio && <Icon name="volume" className={styles.icon} />}
           {title}
         </a>
       </h4>
@@ -37,14 +34,12 @@ TeaserItem.propTypes = {
   url: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   programTitle: PropTypes.string,
-  programUrl: PropTypes.string,
-  hasAudio: PropTypes.bool
+  programUrl: PropTypes.string
 };
 
 TeaserItem.defaultProps = {
   programTitle: null,
-  programUrl: null,
-  hasAudio: false
+  programUrl: null
 };
 
 export default TeaserItem;

--- a/src/components/Molecules/Teaser/__snapshots__/TeaserItem.test.js.snap
+++ b/src/components/Molecules/Teaser/__snapshots__/TeaserItem.test.js.snap
@@ -15,21 +15,6 @@ exports[`<TeaserItem /> Matches the Teaser Item Default snapshot 1`] = `
         className="link"
         href="/"
       >
-        <svg
-          aria-hidden={null}
-          aria-label={null}
-          aria-labelledby={null}
-          className="svg icon"
-          fill="currentcolor"
-          height={28}
-          version={1.1}
-          viewBox="0 0 28 28"
-          width={28}
-        >
-          <path
-            d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-          />
-        </svg>
         Test Title
       </a>
     </h4>
@@ -92,21 +77,6 @@ exports[`<TeaserItem /> Matches the Teaser Item without program snapshot 1`] = `
         className="link"
         href="/"
       >
-        <svg
-          aria-hidden={null}
-          aria-label={null}
-          aria-labelledby={null}
-          className="svg icon"
-          fill="currentcolor"
-          height={28}
-          version={1.1}
-          viewBox="0 0 28 28"
-          width={28}
-        >
-          <path
-            d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-          />
-        </svg>
         Test Title
       </a>
     </h4>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1458,26 +1458,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
     <div
       className="text"
     >
-      <a
-        className="iconLink"
-        href="https://google.com"
-      >
-        <svg
-          aria-hidden={null}
-          aria-label="Audio"
-          aria-labelledby={null}
-          className="svg icon roundIcon"
-          fill="currentcolor"
-          height={28}
-          version={1.1}
-          viewBox="0 0 28 28"
-          width={28}
-        >
-          <path
-            d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-          />
-        </svg>
-      </a>
       <h2>
         <a
           className="title"
@@ -1552,26 +1532,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 className="link"
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
-                <a
-                  className="iconLink"
-                  href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-                >
-                  <svg
-                    aria-hidden={null}
-                    aria-label="Audio"
-                    aria-labelledby={null}
-                    className="svg icon roundIcon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
-                </a>
                 There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco
               </a>
             </h2>
@@ -1678,26 +1638,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 className="link"
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
-                <a
-                  className="iconLink"
-                  href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-                >
-                  <svg
-                    aria-hidden={null}
-                    aria-label="Audio"
-                    aria-labelledby={null}
-                    className="svg icon roundIcon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
-                </a>
                 Progressives in Congress side with Trump on trade
               </a>
             </h2>
@@ -1804,26 +1744,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 className="link"
                 href={null}
               >
-                <a
-                  className="iconLink"
-                  href={null}
-                >
-                  <svg
-                    aria-hidden={null}
-                    aria-label="Audio"
-                    aria-labelledby={null}
-                    className="svg icon roundIcon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
-                </a>
                 Egyptian singer faces the prospect of prison over a joke about the Nile
               </a>
             </h2>
@@ -1879,21 +1799,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                   className="link"
                   href="stories/2018-03-03/poor-and-minority-children-excessive-air-pollution-creates-toxic-learning"
                 >
-                  <svg
-                    aria-hidden={null}
-                    aria-label={null}
-                    aria-labelledby={null}
-                    className="svg icon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
                   For poor and minority children, excessive air pollution creates a toxic learning environment
                 </a>
               </h4>
@@ -1927,21 +1832,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                   className="link"
                   href="stories/2018-03-06/progressives-side-trump-trade"
                 >
-                  <svg
-                    aria-hidden={null}
-                    aria-label={null}
-                    aria-labelledby={null}
-                    className="svg icon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
                   Progressives in Congress side with Trump on trade
                 </a>
               </h4>
@@ -1998,21 +1888,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                   className="link"
                   href="stories/2018-03-06/yet-another-incredible-taco"
                 >
-                  <svg
-                    aria-hidden={null}
-                    aria-label={null}
-                    aria-labelledby={null}
-                    className="svg icon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
                   Yet anther article with an incredible title from the world
                 </a>
               </h4>
@@ -2529,26 +2404,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 className="link"
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
-                <a
-                  className="iconLink"
-                  href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-                >
-                  <svg
-                    aria-hidden={null}
-                    aria-label="Audio"
-                    aria-labelledby={null}
-                    className="svg icon roundIcon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
-                </a>
                 When this Univision anchor interviewed a head of the KKK, he called her the n-word
               </a>
             </h2>
@@ -2612,26 +2467,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 className="link"
                 href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
               >
-                <a
-                  className="iconLink"
-                  href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-                >
-                  <svg
-                    aria-hidden={null}
-                    aria-label="Audio"
-                    aria-labelledby={null}
-                    className="svg icon roundIcon"
-                    fill="currentcolor"
-                    height={28}
-                    version={1.1}
-                    viewBox="0 0 28 28"
-                    width={28}
-                  >
-                    <path
-                      d="M9 10h-4v6h4l5 5v-16l-5 5zM20.36 19.36l-1.41-1.41c1.272-1.265 2.059-3.015 2.059-4.95s-0.787-3.685-2.059-4.95l-0-0 1.41-1.41c1.634 1.625 2.645 3.874 2.645 6.36s-1.011 4.735-2.644 6.36l-0 0zM17.54 16.54l-1.42-1.42c0.542-0.543 0.877-1.292 0.877-2.12s-0.335-1.577-0.877-2.12l0 0 1.42-1.42c0.912 0.903 1.477 2.156 1.477 3.54s-0.565 2.637-1.477 3.54l-0 0z"
-                    />
-                  </svg>
-                </a>
                 There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco
               </a>
             </h2>


### PR DESCRIPTION
## [Remove audio icons from the homepage](https://fourkitchens.atlassian.net/browse/PRISB-416)

**This PR does the following:**
- Removes the audio indication icon from the display. I believe this to be confusing users without the persistent player (at which point we will introduce play buttons).

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Confirm the audio indicator icon doesn't appear anywhere on the homepage.
