### PR TITLE
PRISB-415: adds Live Stream Schedule link to header

### DIFF
--- a/src/components/Organisms/Header/Header.component.js
+++ b/src/components/Organisms/Header/Header.component.js
@@ -71,6 +71,9 @@ export default class Header extends Component {
             icon="play"
           >
             <DropdownItem url={`${baseUrl}/listen`}>Live Stream</DropdownItem>
+            <DropdownItem url={`${baseUrl}/live/schedule`}>
+              Live Stream Schedule
+            </DropdownItem>
             <DropdownItem url={`${baseUrl}/podcasts-program`}>
               Podcasts by Program
             </DropdownItem>


### PR DESCRIPTION
## [Add Live Stream schedule as link on the frontend.](https://fourkitchens.atlassian.net/browse/PRISB-415)

**This PR does the following:**
- Adds a link to the listen dropdown

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Open the Listen dropdown, click on Live Stream Schedule. Ensure it takes you here: https://www.pri.org/live/schedule
