### PR TITLE
PRISB-442: remove AWL newsletter signup

### DIFF
--- a/src/components/Organisms/Header/Header.component.js
+++ b/src/components/Organisms/Header/Header.component.js
@@ -100,11 +100,6 @@ export default class Header extends Component {
             </DropdownItem>
             <DropdownItem isHr />
             <DropdownItem heading="Weekly Newsletters" />
-            <DropdownItem
-              url={`${baseUrl}/subscribe-across-womens-lives-weekly-newsletter`}
-            >
-              Across Women{"'"}s Lives
-            </DropdownItem>
             <DropdownItem url={`${baseUrl}/subscribe-global-nation-newsletter`}>
               Global Nation
             </DropdownItem>


### PR DESCRIPTION
## [Remove AWL newsletter signup throughout the site.](https://fourkitchens.atlassian.net/browse/PRISB-442)

**This PR does the following:**
- Removes the AWL link in the newsletter dropdown

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Go [here](http://localhost:9001/?selectedKind=Pages%2FHome&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) and confirm the AWL newsletter signup has been removed from the newsletter dropdown.