### PR TITLE
fix(header): change donation links in menu

### DIFF
--- a/src/components/Organisms/Header/Header.component.js
+++ b/src/components/Organisms/Header/Header.component.js
@@ -126,7 +126,7 @@ export default class Header extends Component {
           </Dropdown>
 
           <Dropdown
-            url={`${baseUrl}/donate/general?utm_source=navigation&utm_medium=website&utm_campaign=donations`}
+            url={`${baseUrl}/donate/about?utm_source=navigation&utm_medium=website&utm_campaign=donations`}
             title="Donate"
             color="Orange"
             className={styles.button}
@@ -135,7 +135,7 @@ export default class Header extends Component {
             icon="heart"
           >
             <DropdownItem
-              url={`${baseUrl}/donate/index.html?utm_source=navigation&utm_medium=website&utm_campaign=donations`}
+              url={`${baseUrl}/donate/general?utm_source=navigation&utm_medium=website&utm_campaign=donations`}
             >
               Give Now
             </DropdownItem>

--- a/src/components/Organisms/Header/MainMenu.component.js
+++ b/src/components/Organisms/Header/MainMenu.component.js
@@ -78,7 +78,7 @@ export default class MainMenu extends Component {
               <ButtonLink
                 color="Orange"
                 className={styles.btnHeaderRight}
-                url={`${baseUrl}donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations`}
+                url={`${baseUrl}donate/about?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations`}
               >
                 <Icon name="heart" inline ariaHidden />
                 Donate
@@ -342,7 +342,7 @@ export default class MainMenu extends Component {
             accordionList={[
               {
                 name: 'Donate',
-                url: `${baseUrl}donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations`
+                url: `${baseUrl}donate/general?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations`
               }
             ]}
           />

--- a/src/components/Organisms/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Organisms/Header/__snapshots__/Header.test.js.snap
@@ -123,7 +123,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
             </a>
             <a
               className="btnOrange btnHeaderRight"
-              href="https://www.pri.org/donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
+              href="https://www.pri.org/donate/about?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
               onClick={[Function]}
             >
               <svg
@@ -1073,7 +1073,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
               >
                 <a
                   className="listLink accordionContentMenuLink accordionContentMenuLinkOrange "
-                  href="https://www.pri.org/donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
+                  href="https://www.pri.org/donate/general?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
                 >
                   Donate
                 </a>
@@ -1406,7 +1406,7 @@ exports[`<Header /> Matches the Header snapshot 1`] = `
     >
       <a
         className="btnGrp btnMobileOrange"
-        href="https://www.pri.org/donate/general?utm_source=navigation&utm_medium=website&utm_campaign=donations"
+        href="https://www.pri.org/donate/about?utm_source=navigation&utm_medium=website&utm_campaign=donations"
         onClick={[Function]}
       >
         <svg

--- a/src/components/Organisms/Header/__snapshots__/MainMenu.test.js.snap
+++ b/src/components/Organisms/Header/__snapshots__/MainMenu.test.js.snap
@@ -112,7 +112,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
         </a>
         <a
           className="btnOrange btnHeaderRight"
-          href="https://www.pri.org/donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
+          href="https://www.pri.org/donate/about?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
           onClick={[Function]}
         >
           <svg
@@ -1062,7 +1062,7 @@ exports[`<MainMenu /> Matches the Main Menu snapshot 1`] = `
           >
             <a
               className="listLink accordionContentMenuLink accordionContentMenuLinkOrange "
-              href="https://www.pri.org/donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
+              href="https://www.pri.org/donate/general?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
             >
               Donate
             </a>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -124,7 +124,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               </a>
               <a
                 className="btnOrange btnHeaderRight"
-                href="https://www.pri.org/donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
+                href="https://www.pri.org/donate/about?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
                 onClick={[Function]}
               >
                 <svg
@@ -1074,7 +1074,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
                 >
                   <a
                     className="listLink accordionContentMenuLink accordionContentMenuLinkOrange "
-                    href="https://www.pri.org/donate/index.html?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
+                    href="https://www.pri.org/donate/general?utm_source=navigation&amp;utm_medium=website&amp;utm_campaign=donations"
                   >
                     Donate
                   </a>
@@ -1407,7 +1407,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       >
         <a
           className="btnGrp btnMobileOrange"
-          href="https://www.pri.org/donate/general?utm_source=navigation&utm_medium=website&utm_campaign=donations"
+          href="https://www.pri.org/donate/about?utm_source=navigation&utm_medium=website&utm_campaign=donations"
           onClick={[Function]}
         >
           <svg


### PR DESCRIPTION
#106 

**This PR does the following:**
- Updates the donations link in the header to point to proper pages.

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Go [here](http://localhost:9001/?selectedKind=Organisms%2FHeader&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) and ensure the main button points to `/donate/about` and the dropdown item goes to `/donate/general `--- Going to try this.
