### PR TITLE
HOTFIX: list items prop should default to empty array

### DIFF
--- a/src/components/Molecules/Accordion/Accordion.component.js
+++ b/src/components/Molecules/Accordion/Accordion.component.js
@@ -25,7 +25,7 @@ export default class Accordion extends Component {
   };
 
   static defaultProps = {
-    accordionList: {},
+    accordionList: [],
     color: 'Blue',
     listId: null
   };

--- a/src/components/Molecules/List/List.component.js
+++ b/src/components/Molecules/List/List.component.js
@@ -30,7 +30,7 @@ export default class List extends Component {
   };
 
   static defaultProps = {
-    listItems: {},
+    listItems: [],
     className: null,
     ulClass: null,
     liClass: null,


### PR DESCRIPTION
**This PR does the following:**
- Sets default value for `<List>` prop 'listItems` to `[]`. Was `{}`.
- Sets default value for `<Accordion>` prop 'accordionList` to `[]`. Was `{}`.
