### PR TITLE
#113: Add support for freeform card link list

### DIFF
--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -36,31 +36,39 @@ BlurbContent.defaultProps = {
 /**
  * Component that renders a Card Item.
  */
-const CardItem = ({ url, title, imgSrc, imgAlt, blurb, large, freeform }) => (
+const CardItem = ({
+  url,
+  title,
+  imgSrc,
+  imgAlt,
+  blurb,
+  large,
+  freeform,
+  links
+}) => (
   <article
     className={cx({
       cardItem: true,
-      normal: !large && !freeform,
       large,
-      freeform
+      freeform,
+      noImage: !imgSrc
     })}
     typeof="sioc:Item foaf:Document"
   >
-    {imgSrc &&
-      !freeform && (
-        <figure className={cx('image')}>
-          <a href={url}>
-            <LazyLoad>
-              <img
-                typeof="foaf:Image"
-                data-src={imgSrc}
-                alt={imgAlt}
-                className={cx('img')}
-              />
-            </LazyLoad>
-          </a>
-        </figure>
-      )}
+    {imgSrc && (
+      <figure className={cx('image')}>
+        <a href={url}>
+          <LazyLoad>
+            <img
+              typeof="foaf:Image"
+              data-src={imgSrc}
+              alt={imgAlt}
+              className={cx('img')}
+            />
+          </LazyLoad>
+        </a>
+      </figure>
+    )}
     {title && (
       <div className={`${styles.titleWrap}`}>
         <h2 className={`${styles.title}`}>
@@ -78,6 +86,17 @@ const CardItem = ({ url, title, imgSrc, imgAlt, blurb, large, freeform }) => (
         <span dangerouslySetInnerHTML={{ __html: blurb }} />
       </BlurbContent>
     )}
+    {links && (
+      <ul className={`${styles.links}`}>
+        {links.map(({ title: label, url: href }) => (
+          <li className={`${styles.linksItem}`} key={href}>
+            <a className={`${styles.linksLink}`} href={href}>
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
   </article>
 );
 
@@ -88,7 +107,8 @@ CardItem.propTypes = {
   imgAlt: PropTypes.string,
   blurb: PropTypes.node,
   large: PropTypes.bool,
-  freeform: PropTypes.bool
+  freeform: PropTypes.bool,
+  links: PropTypes.arrayOf(PropTypes.object)
 };
 
 CardItem.defaultProps = {
@@ -98,7 +118,8 @@ CardItem.defaultProps = {
   url: null,
   title: null,
   large: false,
-  freeform: false
+  freeform: false,
+  links: null
 };
 
 export default CardItem;

--- a/src/components/Molecules/CardItem/CardItem.component.js
+++ b/src/components/Molecules/CardItem/CardItem.component.js
@@ -88,8 +88,8 @@ const CardItem = ({
     )}
     {links && (
       <ul className={`${styles.links}`}>
-        {links.map(({ title: label, url: href }) => (
-          <li className={`${styles.linksItem}`} key={href}>
+        {links.map(({ title: label, url: href }, index) => (
+          <li className={`${styles.linksItem}`} key={[href, index].join('--')}>
             <a className={`${styles.linksLink}`} href={href}>
               {label}
             </a>

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -61,7 +61,7 @@
   display: block;
   grid-column-start: 1;
   grid-column-end: -1;
-  padding: 0 1rem;
+  margin: 0 0 1rem;
 }
 
 .cardItem.freeform .links {
@@ -174,6 +174,10 @@
 
   .cardItem .title {
     font-size: 1.1rem;
+  }
+
+  .cardItem.freeform .blurb {
+    margin: 0;
   }
 }
 

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -15,7 +15,7 @@
   border-bottom: none;
 }
 
-.cardItem.normal,
+.cardItem,
 .cardItem.freeform {
   padding: 1rem;
 }
@@ -42,26 +42,14 @@
   padding: 0 1rem;
 }
 
-.cardItem.normal .titleWrap {
-  margin: 0;
+.cardItem .titleWrap {
+  margin: 0 0 1rem;
   padding: 0;
 }
 
 .title {
   font-size: 1.1rem;
   margin: 0;
-}
-
-.cardItem.freeform .title {
-  font-size: 1em;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: grayDark;
-}
-
-.cardItem.freeform .link {
-  color: blue;
-  text-decoration: none;
 }
 
 .blurb {
@@ -71,10 +59,23 @@
 
 .cardItem.freeform .blurb {
   display: block;
+  grid-column-start: 1;
+  grid-column-end: -1;
+  padding: 0 1rem;
+}
+
+.cardItem.freeform .links {
+  grid-column-start: 1;
+  grid-column-end: -1;
+  margin: 0 -1rem -1rem;
+}
+
+.cardItem.freeform.large .links {
+  margin: 0 0 -2rem;
 }
 
 .blurb h2 {
-  font-size: 1.5rem;
+  font-size: 1.1rem;
 }
 
 .blurb h2 a,
@@ -99,6 +100,10 @@
   margin-top: 1rem;
 }
 
+.blurb :last-child {
+  margin-bottom: 0;
+}
+
 .iconLink {
   color: white;
   position: relative;
@@ -115,42 +120,84 @@
   margin-right: 0.25em;
 }
 
+.linksItem {
+  margin: 0;
+  padding: 10px 20px;
+  list-style: none;
+  border-top: 1px solid #ddd;
+  font-size: 0.9em;
+}
+
+.linksLink {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
 @media bp-phone {
-  .cardItem.normal {
+  .cardItem {
     display: grid;
-    grid-template-rows: auto auto;
-    grid-template-columns: 40% auto;
-    grid-column-gap: 1rem;
+    grid-template-columns: 40% 1fr;
+    grid-gap: 1rem;
     grid-template-areas: 'IMAGE TITLE';
+  }
+
+  .cardItem.freeform {
+    grid-template-areas:
+      'IMAGE IMAGE'
+      'TITLE TITLE'
+      'BLURB BLURB';
+  }
+
+  .cardItem.large {
+    grid-template-areas:
+      'IMAGE IMAGE'
+      'TITLE TITLE';
+  }
+
+  .cardItem.noImage {
+    grid-template-areas: 'TITLE TITLE';
   }
 
   .image {
     display: block;
   }
 
-  .cardItem.normal .image {
+  .cardItem .image {
     grid-area: IMAGE;
   }
 
-  .cardItem.normal .titleWrap {
+  .cardItem .titleWrap {
     grid-area: TITLE;
     align-self: center;
+    margin: 0;
   }
 
-  .cardItem.normal .title {
+  .cardItem .title {
     font-size: 1.1rem;
   }
 }
 
 @media bp-tablet {
-  .cardItem.normal {
-    grid-row-gap: 0.5rem;
+  .cardItem {
     grid-template-areas:
       'IMAGE TITLE'
       'IMAGE BLURB';
   }
 
-  .cardItem.normal .titleWrap {
+  .cardItem.large {
+    grid-template-areas:
+      'IMAGE IMAGE'
+      'TITLE TITLE'
+      'BLURB BLURB';
+  }
+
+  .cardItem.noImage {
+    grid-template-areas:
+      'TITLE TITLE'
+      'BLURB BLURB';
+  }
+
+  .cardItem .titleWrap {
     align-self: end;
   }
 
@@ -162,18 +209,26 @@
     display: block;
   }
 
-  .blurb h2 {
-    font-size: 1.75rem;
-  }
-
-  .cardItem.normal .blurb {
+  .cardItem .blurb {
     grid-area: BLURB;
     align-self: start;
     margin: 0;
   }
 
   .cardItem.large .blurb {
-    margin: 1rem 0;
+    margin: 0;
     padding: 0 1rem;
+  }
+
+  .cardItem.freeform.noImage .title {
+    font-size: 1em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: grayDark;
+  }
+
+  .cardItem.freeform.noImage .link {
+    color: blue;
+    text-decoration: none;
   }
 }

--- a/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
+++ b/src/components/Molecules/CardItem/__snapshots__/CardItem.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
 <article
-  className="cardItem normal"
+  className="cardItem"
   typeof="sioc:Item foaf:Document"
 >
   <figure
@@ -58,7 +58,7 @@ exports[`<CardItem /> Matches the Card Item Default snapshot 1`] = `
 
 exports[`<CardItem /> Matches the Card Item Large snapshot 1`] = `
 <article
-  className="cardItem large"
+  className="cardItem large noImage"
   typeof="sioc:Item foaf:Document"
 >
   <div
@@ -92,6 +92,20 @@ exports[`<CardItem /> Matches the Card Item No Link snapshot 1`] = `
   className="cardItem freeform"
   typeof="sioc:Item foaf:Document"
 >
+  <figure
+    className="image"
+  >
+    <a
+      href={null}
+    >
+      <img
+        alt={null}
+        className="img"
+        data-src="http://placehold.it/1920x1080.png"
+        typeof="foaf:Image"
+      />
+    </a>
+  </figure>
   <div
     className="titleWrap"
   >

--- a/src/components/Molecules/molecules.story.js
+++ b/src/components/Molecules/molecules.story.js
@@ -134,6 +134,54 @@ storiesOf('Molecules/CardItem', module)
         '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
       }
     />
+  ))
+  .add('Freeform w/Links', () => (
+    <CardItem
+      title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+      url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+      imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+      imgAlt="Alt Text"
+      blurb={
+        '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
+      }
+      freeform
+      links={[
+        {
+          url:
+            'https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction',
+          title:
+            "Mueller's Russia report outlines episodes of possible Trump obstruction",
+          attributes: []
+        },
+        {
+          url:
+            'https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia',
+          title: 'Smoke or fire? Contacts between Trump campaign and Russia',
+          attributes: []
+        },
+        {
+          url:
+            'https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report',
+          title:
+            "Factbox: Five things to look for in Mueller's Trump-Russia report",
+          attributes: []
+        },
+        {
+          url:
+            'https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election',
+          title:
+            'Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election',
+          attributes: []
+        },
+        {
+          url:
+            'https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents',
+          title:
+            "'Secrecy is subjective' when government censors redact documents",
+          attributes: []
+        }
+      ]}
+    />
   ));
 
 /**

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -26,6 +26,27 @@ import BlockList from './BlockList/BlockList.component';
  */
 storiesOf('Organisms/CardList', module)
   .addDecorator(checkA11y)
+  .addDecorator(story => (
+    <div
+      style={{
+        position: 'absolute',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        minHeight: '100vh'
+      }}
+    >
+      <div
+        style={{
+          margin: '2rem 0',
+          maxWidth: '690px'
+        }}
+      >
+        {story()}
+      </div>
+    </div>
+  ))
   .add('Card List with Image', () => (
     <CardList
       logo="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
@@ -37,7 +58,7 @@ storiesOf('Organisms/CardList', module)
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
         url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/180302copbridge.jpg?itok=52GppaOv"
         imgAlt="Alt Text"
         blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
         large
@@ -72,17 +93,60 @@ storiesOf('Organisms/CardList', module)
         blurb="An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'"
         hasAudio
       />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb={
+          '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
+        }
+        freeform
+        links={[
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction',
+            title:
+              "Mueller's Russia report outlines episodes of possible Trump obstruction",
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia',
+            title: 'Smoke or fire? Contacts between Trump campaign and Russia',
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report',
+            title:
+              "Factbox: Five things to look for in Mueller's Trump-Russia report",
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election',
+            title:
+              'Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election',
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents',
+            title:
+              "'Secrecy is subjective' when government censors redact documents",
+            attributes: []
+          }
+        ]}
+      />
     </CardList>
-  ));
-
-storiesOf('Organisms/CardList', module)
-  .addDecorator(checkA11y)
+  ))
   .add('Without Image', () => (
     <CardList name="pris-the-world" url="#" title="PRI's The World">
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
         url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/180302copbridge.jpg?itok=52GppaOv"
         imgAlt="Alt Text"
         blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
         large
@@ -104,16 +168,13 @@ storiesOf('Organisms/CardList', module)
         hasAudio
       />
     </CardList>
-  ));
-
-storiesOf('Organisms/CardList', module)
-  .addDecorator(checkA11y)
+  ))
   .add('Without URL', () => (
     <CardList name="custom-header" title="Custom Header">
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
         url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/180302copbridge.jpg?itok=52GppaOv"
         imgAlt="Alt Text"
         blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
         large
@@ -135,16 +196,13 @@ storiesOf('Organisms/CardList', module)
         hasAudio
       />
     </CardList>
-  ));
-
-storiesOf('Organisms/CardList', module)
-  .addDecorator(checkA11y)
+  ))
   .add('Without Header', () => (
     <CardList name="no-header">
       <CardItem
         title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
         url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-        imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/180302copbridge.jpg?itok=52GppaOv"
         imgAlt="Alt Text"
         blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
         large
@@ -163,6 +221,194 @@ storiesOf('Organisms/CardList', module)
         imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
         imgAlt="Alt Text"
         blurb="NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. "
+        hasAudio
+      />
+    </CardList>
+  ))
+  .add('With Freeform Item', () => (
+    <CardList
+      logo="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
+      name="pris-the-world"
+      id="program-with-logo"
+      url="#"
+      title="PRI's The World"
+    >
+      <CardItem
+        title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgAlt="Alt Text"
+        blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
+        large
+        hasAudio
+      />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+      />
+      <CardItem
+        title="Progressives in Congress side with Trump on trade"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
+        imgAlt="Alt Text"
+        blurb="NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. "
+        hasAudio
+      />
+      <CardItem
+        title="A cartoonist in Equatorial Guinea has been cleared of charges, but he's still in jail"
+        url="https://interactive-dev.pri.org/stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
+        imgAlt="Alt Text"
+        blurb="Charges against a jailed cartoonist from Equatorial Guinea have been dropped, so why is he still in jail?"
+      />
+      <CardItem
+        title="Egyptian singer faces the prospect of prison over a joke about the Nile"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
+        imgAlt="Alt Text"
+        blurb="An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'"
+        hasAudio
+      />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb={
+          '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
+        }
+        freeform
+        links={[
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction',
+            title:
+              "Mueller's Russia report outlines episodes of possible Trump obstruction",
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia',
+            title: 'Smoke or fire? Contacts between Trump campaign and Russia',
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report',
+            title:
+              "Factbox: Five things to look for in Mueller's Trump-Russia report",
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election',
+            title:
+              'Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election',
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents',
+            title:
+              "'Secrecy is subjective' when government censors redact documents",
+            attributes: []
+          }
+        ]}
+      />
+    </CardList>
+  ))
+  .add('With Freeform Hero', () => (
+    <CardList
+      logo="https://interactive-dev.pri.org/staging/prototypes/homepage/themes/pri/images/logo_tw.png"
+      name="pris-the-world"
+      id="program-with-logo"
+      url="#"
+      title="PRI's The World"
+    >
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb={
+          '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
+        }
+        freeform
+        large
+        links={[
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction',
+            title:
+              "Mueller's Russia report outlines episodes of possible Trump obstruction",
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia',
+            title: 'Smoke or fire? Contacts between Trump campaign and Russia',
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report',
+            title:
+              "Factbox: Five things to look for in Mueller's Trump-Russia report",
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election',
+            title:
+              'Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election',
+            attributes: []
+          },
+          {
+            url:
+              'https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents',
+            title:
+              "'Secrecy is subjective' when government censors redact documents",
+            attributes: []
+          }
+        ]}
+      />
+      <CardItem
+        title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/180302copbridge.jpg?itok=52GppaOv"
+        imgAlt="Alt Text"
+        blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
+        hasAudio
+      />
+      <CardItem
+        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+        imgAlt="Alt Text"
+        blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+      />
+      <CardItem
+        title="Progressives in Congress side with Trump on trade"
+        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/DeLauro.jpg?itok=gprExR5S"
+        imgAlt="Alt Text"
+        blurb="NAFTA has governed the rules of trade between the US, Mexico and Canada since 1994. Today, many progressives who dislike NAFTA say President Trump is giving them the best chance in a generation to rewrite the rules of trade. "
+        hasAudio
+      />
+      <CardItem
+        title="A cartoonist in Equatorial Guinea has been cleared of charges, but he's still in jail"
+        url="https://interactive-dev.pri.org/stories/2017-07-24/clearing-mines-and-explosives-mosul"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
+        imgAlt="Alt Text"
+        blurb="Charges against a jailed cartoonist from Equatorial Guinea have been dropped, so why is he still in jail?"
+      />
+      <CardItem
+        title="Egyptian singer faces the prospect of prison over a joke about the Nile"
+        imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/GettyImages-925030722_master.jpg?itok=LSMUCQbS"
+        imgAlt="Alt Text"
+        blurb="An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'"
         hasAudio
       />
     </CardList>

--- a/src/components/Pages/Home/Home.component.js
+++ b/src/components/Pages/Home/Home.component.js
@@ -300,20 +300,52 @@ const Home = ({ baseUrl }) => (
           title="Custom Card Header"
         >
           <CardItem
-            title="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
-            url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-            imgSrc="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
-            imgAlt="Alt Text"
-            blurb="Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food."
-            large
-            hasAudio
-          />
-          <CardItem
             title="50 years on, India is celebrating the Beatles' infamous trip to the country"
             url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-            imgSrc="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+            imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
             imgAlt="Alt Text"
-            blurb="When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. "
+            blurb={
+              '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
+            }
+            freeform
+            large
+            links={[
+              {
+                url:
+                  'https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction',
+                title:
+                  "Mueller's Russia report outlines episodes of possible Trump obstruction",
+                attributes: []
+              },
+              {
+                url:
+                  'https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia',
+                title:
+                  'Smoke or fire? Contacts between Trump campaign and Russia',
+                attributes: []
+              },
+              {
+                url:
+                  'https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report',
+                title:
+                  "Factbox: Five things to look for in Mueller's Trump-Russia report",
+                attributes: []
+              },
+              {
+                url:
+                  'https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election',
+                title:
+                  'Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election',
+                attributes: []
+              },
+              {
+                url:
+                  'https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents',
+                title:
+                  "'Secrecy is subjective' when government censors redact documents",
+                attributes: []
+              }
+            ]}
           />
         </CardList>
       </LayoutMainList2>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -261,7 +261,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
         <article
-          className="cardItem normal"
+          className="cardItem"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -314,7 +314,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
         <article
-          className="cardItem normal"
+          className="cardItem"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -367,7 +367,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
         <article
-          className="cardItem normal"
+          className="cardItem"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -420,7 +420,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
         <article
-          className="cardItem normal"
+          className="cardItem"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -1027,7 +1027,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
         <article
-          className="cardItem normal"
+          className="cardItem"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -1080,7 +1080,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           </p>
         </article>
         <article
-          className="cardItem normal"
+          className="cardItem"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -1143,7 +1143,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
           Custom Card Header
         </header>
         <article
-          className="cardItem large"
+          className="cardItem large freeform"
           typeof="sioc:Item foaf:Document"
         >
           <figure
@@ -1155,60 +1155,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               <img
                 alt="Alt Text"
                 className="img"
-                data-src="https://media.pri.org/s3fs-public/styles/feature_medium/public/story/images/180302copbridge.jpg?itok=52GppaOv"
-                typeof="foaf:Image"
-              />
-            </a>
-          </figure>
-          <div
-            className="titleWrap"
-          >
-            <h2
-              className="title"
-            >
-              <a
-                className="link"
-                href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-              >
-                There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco
-              </a>
-            </h2>
-            <span
-              content="There is one place where Serbs and Albanians coexist in Kosovo — in the country's version of Costco"
-              property="dc:title"
-            />
-            <span
-              content="0"
-              datatype="xsd:integer"
-              property="sioc:num_replies"
-            />
-          </div>
-          <p
-            className="blurb"
-          >
-            <span
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "Ten years after Kosovo declared its independence from Serbia, Serbs and Albanians in Kosovo remain deeply divided — even over food.",
-                }
-              }
-            />
-          </p>
-        </article>
-        <article
-          className="cardItem normal"
-          typeof="sioc:Item foaf:Document"
-        >
-          <figure
-            className="image"
-          >
-            <a
-              href="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-            >
-              <img
-                alt="Alt Text"
-                className="img"
-                data-src="https://media.pri.org/s3fs-public/styles/feature_small/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
+                data-src="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
                 typeof="foaf:Image"
               />
             </a>
@@ -1236,17 +1183,71 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
               property="sioc:num_replies"
             />
           </div>
-          <p
+          <div
             className="blurb"
           >
             <span
               dangerouslySetInnerHTML={
                 Object {
-                  "__html": "When the Beatles embarked on their famous discovery of India to study transcendental meditation, the Indian government was far more wary. ",
+                  "__html": "<h2>Header within a freeform body</h2><h2><a href=\\"#\\">Header within a freeform body and has a link</a></h2><blockquote><p>\\"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe.\\"</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href=\\"#\\">This is a link</a></p>",
                 }
               }
             />
-          </p>
+          </div>
+          <ul
+            className="links"
+          >
+            <li
+              className="linksItem"
+            >
+              <a
+                className="linksLink"
+                href="https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction"
+              >
+                Mueller's Russia report outlines episodes of possible Trump obstruction
+              </a>
+            </li>
+            <li
+              className="linksItem"
+            >
+              <a
+                className="linksLink"
+                href="https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia"
+              >
+                Smoke or fire? Contacts between Trump campaign and Russia
+              </a>
+            </li>
+            <li
+              className="linksItem"
+            >
+              <a
+                className="linksLink"
+                href="https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report"
+              >
+                Factbox: Five things to look for in Mueller's Trump-Russia report
+              </a>
+            </li>
+            <li
+              className="linksItem"
+            >
+              <a
+                className="linksLink"
+                href="https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election"
+              >
+                Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election
+              </a>
+            </li>
+            <li
+              className="linksItem"
+            >
+              <a
+                className="linksLink"
+                href="https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents"
+              >
+                'Secrecy is subjective' when government censors redact documents
+              </a>
+            </li>
+          </ul>
         </article>
       </section>
     </section>


### PR DESCRIPTION
#113

**This PR does the following:**
- Adds link list to freeform card items
- Adds images to freeform card items
- Updates card item styles to accommodate layout changes

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [ ] Ensure __Molecules > CardItem__ stories look and behave as expected.
- [ ] Ensure __Organisms > CardList__ stories look and behave as expected.
- [ ] Ensure __Pages > Home__ stories look and behave as expected.
