### PR TITLE
HOTFIX: Cleanup card layout styles

### DIFF
--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -165,7 +165,7 @@
       'TITLE TITLE';
   }
 
-  .cardItem.large .titleWrap {
+  .cardItem.large:not(.freeform) .titleWrap {
     margin-top: 0;
   }
 

--- a/src/components/Molecules/CardItem/CardItem.css
+++ b/src/components/Molecules/CardItem/CardItem.css
@@ -15,13 +15,12 @@
   border-bottom: none;
 }
 
-.cardItem,
-.cardItem.freeform {
+.cardItem {
   padding: 1rem;
 }
 
-.cardItem.large {
-  padding: 0 0 2rem;
+.cardItem > * + * {
+  margin-top: 1rem;
 }
 
 .image {
@@ -33,18 +32,8 @@
   width: 100%;
 }
 
-.cardItem.large .image {
-  display: block;
-}
-
-.cardItem.large .titleWrap {
-  margin-top: 1rem;
-  padding: 0 1rem;
-}
-
-.cardItem .titleWrap {
-  margin: 0 0 1rem;
-  padding: 0;
+.titleWrap {
+  margin-top: 0;
 }
 
 .title {
@@ -57,21 +46,34 @@
   line-height: 1.3;
 }
 
+.cardItem.large {
+  padding-bottom: 2rem;
+}
+
+.cardItem.large .titleWrap {
+  margin-top: 1rem;
+}
+
+.cardItem.large .image {
+  display: block;
+  margin: -1rem -1rem 0;
+}
+
+.cardItem.freeform {
+  display: flex;
+  flex-direction: column;
+}
+
+.cardItem.freeform .titleWrap {
+  margin-top: 1rem;
+}
+
 .cardItem.freeform .blurb {
   display: block;
-  grid-column-start: 1;
-  grid-column-end: -1;
-  margin: 0 0 1rem;
 }
 
 .cardItem.freeform .links {
-  grid-column-start: 1;
-  grid-column-end: -1;
-  margin: 0 -1rem -1rem;
-}
-
-.cardItem.freeform.large .links {
-  margin: 0 0 -2rem;
+  margin: 1rem -1rem -1rem;
 }
 
 .blurb h2 {
@@ -141,23 +143,6 @@
     grid-template-areas: 'IMAGE TITLE';
   }
 
-  .cardItem.freeform {
-    grid-template-areas:
-      'IMAGE IMAGE'
-      'TITLE TITLE'
-      'BLURB BLURB';
-  }
-
-  .cardItem.large {
-    grid-template-areas:
-      'IMAGE IMAGE'
-      'TITLE TITLE';
-  }
-
-  .cardItem.noImage {
-    grid-template-areas: 'TITLE TITLE';
-  }
-
   .image {
     display: block;
   }
@@ -168,16 +153,24 @@
 
   .cardItem .titleWrap {
     grid-area: TITLE;
-    align-self: center;
-    margin: 0;
   }
 
   .cardItem .title {
     font-size: 1.1rem;
   }
 
-  .cardItem.freeform .blurb {
-    margin: 0;
+  .cardItem.large {
+    grid-template-areas:
+      'IMAGE IMAGE'
+      'TITLE TITLE';
+  }
+
+  .cardItem.large .titleWrap {
+    margin-top: 0;
+  }
+
+  .cardItem.noImage {
+    grid-template-areas: 'TITLE TITLE';
   }
 }
 
@@ -201,10 +194,6 @@
       'BLURB BLURB';
   }
 
-  .cardItem .titleWrap {
-    align-self: end;
-  }
-
   .title {
     font-size: 1.5rem;
   }
@@ -213,15 +202,14 @@
     display: block;
   }
 
-  .cardItem .blurb {
+  .cardItem:not(.freeform) .titleWrap {
+    align-self: end;
+  }
+
+  .cardItem:not(.freeform) .blurb {
     grid-area: BLURB;
     align-self: start;
     margin: 0;
-  }
-
-  .cardItem.large .blurb {
-    margin: 0;
-    padding: 0 1rem;
   }
 
   .cardItem.freeform.noImage .title {

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -93,52 +93,6 @@ storiesOf('Organisms/CardList', module)
         blurb="An Egyptian court has sentenced one of its country's top singers to six months in prison for a comment she made about the Nile River. Pop singer Sherine made a crack about getting ill from drinking from the river when she was asked by a fan to sing, 'Have You Ever Drunk From the Nile.'"
         hasAudio
       />
-      <CardItem
-        title="50 years on, India is celebrating the Beatles' infamous trip to the country"
-        url="stories/2017-07-24/clearing-mines-and-explosives-mosul"
-        imgSrc="https://media.pri.org/s3fs-public/styles/story_main/public/story/images/Beatles_India_02.jpg?itok=iG8TKNDu"
-        imgAlt="Alt Text"
-        blurb={
-          '<h2>Header within a freeform body</h2><h2><a href="#">Header within a freeform body and has a link</a></h2><blockquote><p>"Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe."</p></blockquote><p>Science and stories for a meaningful life. Hosted by award-winning professor Dacher Keltner, The Science of Happiness highlights the most provocative and practical findings to have emerged from the ground-breaking science of compassion, gratitude, mindfulness, and awe. A co-production with the Greater Good Science Center at UC Berkeley. <a href="#">This is a link</a></p>'
-        }
-        freeform
-        links={[
-          {
-            url:
-              'https://www.pri.org/stories/2019-04-18/muellers-russia-report-outlines-episodes-possible-trump-obstruction',
-            title:
-              "Mueller's Russia report outlines episodes of possible Trump obstruction",
-            attributes: []
-          },
-          {
-            url:
-              'https://www.pri.org/stories/2019-03-22/smoke-or-fire-contacts-between-trump-campaign-and-russia',
-            title: 'Smoke or fire? Contacts between Trump campaign and Russia',
-            attributes: []
-          },
-          {
-            url:
-              'https://www.pri.org/stories/2019-04-18/factbox-five-things-look-muellers-trump-russia-report',
-            title:
-              "Factbox: Five things to look for in Mueller's Trump-Russia report",
-            attributes: []
-          },
-          {
-            url:
-              'https://www.pri.org/stories/2019-04-18/timeline-big-moments-mueller-investigation-russian-meddling-2016-us-election',
-            title:
-              'Timeline: Big moments in Mueller investigation of Russian meddling in 2016 US election',
-            attributes: []
-          },
-          {
-            url:
-              'https://www.pri.org/stories/2019-04-17/secrecy-subjective-when-government-censors-redact-documents',
-            title:
-              "'Secrecy is subjective' when government censors redact documents",
-            attributes: []
-          }
-        ]}
-      />
     </CardList>
   ))
   .add('Without Image', () => (


### PR DESCRIPTION
**This PR does the following:**
- Cleans up layout styles of card items across screen sizes. There were some contradicting techniques used that made overrides inconsistent.

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Ensure CardItem, CardList, and Home page stories layout as expected at all screen sizes.
