### PR TITLE
feat(footer): add new funder

### DIFF
--- a/src/components/Organisms/Footer/Footer.component.js
+++ b/src/components/Organisms/Footer/Footer.component.js
@@ -10,10 +10,6 @@ import styles from './Footer.css';
 import PriLogo from '../../Atoms/Svg/PriLogo.component';
 import List from '../../Molecules/List/List.component';
 
-import carnegieSponsorImg from './images/carnegie.jpg';
-import fordSponsorImg from './images/ford.jpg';
-import macarthurSponsorImg from './images/macarthur.jpg';
-
 /**
  * Component that renders the footer.
  */
@@ -36,7 +32,7 @@ const Footer = ({ links }) => (
           alt="Carnegie Corporation of New York"
           title="Carnegie Corporation of New York"
           typeof="foaf:Image"
-          src={carnegieSponsorImg}
+          src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/carnegie.jpg"
         />
       </a>
       <a
@@ -51,7 +47,7 @@ const Footer = ({ links }) => (
           alt="MacArthur Foundation"
           title="MacArthur Foundation"
           typeof="foaf:Image"
-          src={macarthurSponsorImg}
+          src="https://media.pri.org/s3fs-public/logo-macarthur-color.jpg"
         />
       </a>
       <a
@@ -66,10 +62,24 @@ const Footer = ({ links }) => (
           alt="Ford Foundation"
           title="Ford Foundation"
           typeof="foaf:Image"
-          src={fordSponsorImg}
+          src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/ford.jpg"
         />
       </a>
-      <p>A Partner of OZY Media News</p>
+      <a
+        className={styles.sponsor}
+        href="https://cpb.org/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          height="52"
+          width="149"
+          alt="Corporation for Public Broadcasting"
+          title="Corporation for Public Broadcasting"
+          typeof="foaf:Image"
+          src="https://media.pri.org/s3fs-public/images/2020/01/cpb-logo.png"
+        />
+      </a>
     </section>
 
     <section className={styles.footerBtm}>

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -48,7 +48,7 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
       <img
         alt="Carnegie Corporation of New York"
         height="52"
-        src="test-file-stub"
+        src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/carnegie.jpg"
         title="Carnegie Corporation of New York"
         typeof="foaf:Image"
         width="149"
@@ -63,7 +63,7 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
       <img
         alt="MacArthur Foundation"
         height="52"
-        src="test-file-stub"
+        src="https://media.pri.org/s3fs-public/logo-macarthur-color.jpg"
         title="MacArthur Foundation"
         typeof="foaf:Image"
         width="149"
@@ -78,22 +78,34 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
       <img
         alt="Ford Foundation"
         height="52"
-        src="test-file-stub"
+        src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/ford.jpg"
         title="Ford Foundation"
         typeof="foaf:Image"
         width="149"
       />
     </a>
-    <p>
-      A Partner of OZY Media News
-    </p>
+    <a
+      className="sponsor"
+      href="https://cpb.org/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <img
+        alt="Corporation for Public Broadcasting"
+        height="52"
+        src="https://media.pri.org/s3fs-public/images/2020/01/cpb-logo.png"
+        title="Corporation for Public Broadcasting"
+        typeof="foaf:Image"
+        width="149"
+      />
+    </a>
   </section>
   <section
     className="footerBtm"
   >
     <p>
       © 
-      2019
+      2020
        Public Radio International
     </p>
   </section>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1287,7 +1287,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
         <img
           alt="Carnegie Corporation of New York"
           height="52"
-          src="test-file-stub"
+          src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/carnegie.jpg"
           title="Carnegie Corporation of New York"
           typeof="foaf:Image"
           width="149"
@@ -1302,7 +1302,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
         <img
           alt="MacArthur Foundation"
           height="52"
-          src="test-file-stub"
+          src="https://media.pri.org/s3fs-public/logo-macarthur-color.jpg"
           title="MacArthur Foundation"
           typeof="foaf:Image"
           width="149"
@@ -1317,15 +1317,27 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
         <img
           alt="Ford Foundation"
           height="52"
-          src="test-file-stub"
+          src="https://media.pri.org/s3fs-public/styles/original_image/public/images/2018/09/ford.jpg"
           title="Ford Foundation"
           typeof="foaf:Image"
           width="149"
         />
       </a>
-      <p>
-        A Partner of OZY Media News
-      </p>
+      <a
+        className="sponsor"
+        href="https://cpb.org/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <img
+          alt="Corporation for Public Broadcasting"
+          height="52"
+          src="https://media.pri.org/s3fs-public/images/2020/01/cpb-logo.png"
+          title="Corporation for Public Broadcasting"
+          typeof="foaf:Image"
+          width="149"
+        />
+      </a>
     </section>
     <section
       className="footerBtm"
@@ -1403,7 +1415,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       </div>
       <p>
         © 
-        2019
+        2020
          Public Radio International
       </p>
     </section>


### PR DESCRIPTION
**This PR does the following:**
- Adds CBP as funder
- All images point to media.pri.org (Share the same image as the one on the Drupal site footer)

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Confirm CPB shows up as a new funder, properly linked
- [x] All images point to media.pri.org (Share the same image as the one on the Drupal site footer)