### PR TITLE
Remove BBC logo from footer

### DIFF
--- a/src/components/Organisms/Footer/Footer.component.js
+++ b/src/components/Organisms/Footer/Footer.component.js
@@ -49,21 +49,6 @@ const Footer = ({ links }) => (
       </a>
       <a
         className={styles.sponsor}
-        href="https://www.bbc.org/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <img
-          height="25"
-          width="84"
-          alt="BBC"
-          title="BBC"
-          typeof="foaf:Image"
-          src="https://media.pri.org/s3fs-public/images/2020/04/logo-bbc.png"
-        />
-      </a>
-      <a
-        className={styles.sponsor}
         href="https://www.wgbh.org/"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -77,21 +77,6 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
     </a>
     <a
       className="sponsor"
-      href="https://www.bbc.org/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <img
-        alt="BBC"
-        height="25"
-        src="https://media.pri.org/s3fs-public/images/2020/04/logo-bbc.png"
-        title="BBC"
-        typeof="foaf:Image"
-        width="84"
-      />
-    </a>
-    <a
-      className="sponsor"
       href="https://www.wgbh.org/"
       rel="noopener noreferrer"
       target="_blank"

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1005,21 +1005,6 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       </a>
       <a
         className="sponsor"
-        href="https://www.bbc.org/"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        <img
-          alt="BBC"
-          height="25"
-          src="https://media.pri.org/s3fs-public/images/2020/04/logo-bbc.png"
-          title="BBC"
-          typeof="foaf:Image"
-          width="84"
-        />
-      </a>
-      <a
-        className="sponsor"
         href="https://www.wgbh.org/"
         rel="noopener noreferrer"
         target="_blank"


### PR DESCRIPTION
**This PR does the following:**
- Removes the BBC logo from the site footer

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Organisms > Footer > ensure the BBC logo is NOT present.
