### PR TITLE
Swap gbh logo

### DIFF
--- a/src/components/Organisms/Footer/Footer.component.js
+++ b/src/components/Organisms/Footer/Footer.component.js
@@ -43,17 +43,17 @@ const Footer = ({ links }) => (
       </a>
       <a
         className={styles.sponsor}
-        href="https://www.wgbh.org/"
+        href="https://gbh.org/"
         target="_blank"
         rel="noopener noreferrer"
       >
         <img
           height="25"
-          width="84"
-          alt="WGBH"
-          title="WGBH"
+          width="48"
+          alt="GBH"
+          title="GBH"
           typeof="foaf:Image"
-          src="https://media.pri.org/s3fs-public/images/2020/04/logo-wgbh.png"
+          src="https://media.pri.org/s3fs-public/images/2020/08/gbh_logo_purple-95x50.png"
         />
       </a>
       <p>

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -77,17 +77,17 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
     </a>
     <a
       className="sponsor"
-      href="https://www.wgbh.org/"
+      href="https://gbh.org/"
       rel="noopener noreferrer"
       target="_blank"
     >
       <img
-        alt="WGBH"
+        alt="GBH"
         height="25"
-        src="https://media.pri.org/s3fs-public/images/2020/04/logo-wgbh.png"
-        title="WGBH"
+        src="https://media.pri.org/s3fs-public/images/2020/08/gbh_logo_purple-95x50.png"
+        title="GBH"
         typeof="foaf:Image"
-        width="84"
+        width="48"
       />
     </a>
     <p>

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1167,17 +1167,17 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       </a>
       <a
         className="sponsor"
-        href="https://www.wgbh.org/"
+        href="https://gbh.org/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <img
-          alt="WGBH"
+          alt="GBH"
           height="25"
-          src="https://media.pri.org/s3fs-public/images/2020/04/logo-wgbh.png"
-          title="WGBH"
+          src="https://media.pri.org/s3fs-public/images/2020/08/gbh_logo_purple-95x50.png"
+          title="GBH"
           typeof="foaf:Image"
-          width="84"
+          width="48"
         />
       </a>
       <p>


### PR DESCRIPTION
**This PR does the following:**
- Updates WGBH footer assets to be GBH. 

### To Review:

- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Molecules > Footer - note the new logo next to the PRX logo. Click link ensure it resolves at wgbh website (I updated it to gbh.org anticipating they'll do a domain swap)
