### PR TITLE
#148: Transfer menu item attrs to links

### DIFF
--- a/src/components/Atoms/Button/ButtonLink.component.js
+++ b/src/components/Atoms/Button/ButtonLink.component.js
@@ -14,7 +14,7 @@ const cx = classNames.bind(styles);
  * Component that renders a link button with a click handler.
  */
 const ButtonLink = props => {
-  const { url, onClick, className, children, color, small } = props;
+  const { url, onClick, className, children, color, small, ...other } = props;
   // Generate a class name based on the color.
   const buttonClass = cx({
     [`btn${color}`]: !small,
@@ -23,7 +23,7 @@ const ButtonLink = props => {
   });
 
   return (
-    <a href={url} className={buttonClass} onClick={onClick}>
+    <a href={url} className={buttonClass} onClick={onClick} {...other}>
       {children}
     </a>
   );

--- a/src/components/Atoms/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Atoms/Button/__snapshots__/Button.test.js.snap
@@ -46,6 +46,7 @@ exports[`<ButtonLink /> Matches the Button Link snapshot 1`] = `
   className="btnWhite White"
   href="https://google.com"
   onClick={[MockFunction]}
+  title="test"
 >
   test
 </a>

--- a/src/components/Molecules/List/List.component.js
+++ b/src/components/Molecules/List/List.component.js
@@ -78,11 +78,13 @@ export default class List extends Component {
             item.itemLinkClass !== undefined ? styles[item.itemLinkClass] : ''
           }`}
           href={item.url}
+          {...item.attributes}
         >
           {item.name}
         </a>
       </li>
     ));
+
     return (
       <div
         className={listWrapClasses}

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -161,7 +161,7 @@ exports[`<Footer /> Matches the Footer snapshot 1`] = `
   >
     <p>
       © 
-      2020
+      2021
        The World from PRX
     </p>
     <p>

--- a/src/components/Organisms/Header/Header.component.js
+++ b/src/components/Organisms/Header/Header.component.js
@@ -40,7 +40,7 @@ export default class Header extends Component {
 
     const headerNavButtons =
       headerNav &&
-      headerNav.map(({ name, url, icon, color }) => {
+      headerNav.map(({ name, url, icon, color, attributes }) => {
         const buttonClasses = cx({
           button: true,
           buttonHasIcon: icon
@@ -51,6 +51,7 @@ export default class Header extends Component {
             color={color}
             url={url}
             key={name}
+            {...attributes}
           >
             {icon && <Icon name={icon} className={styles.buttonIcon} />} {name}
           </ButtonLink>

--- a/src/components/Organisms/Header/MainMenu.component.js
+++ b/src/components/Organisms/Header/MainMenu.component.js
@@ -49,12 +49,13 @@ export default class MainMenu extends Component {
 
     const topNavButtons =
       drawerTopNav &&
-      drawerTopNav.map(({ name, url }) => (
+      drawerTopNav.map(({ name, url, attributes }) => (
         <ButtonLink
           color="Orange"
           className={styles.btnGroupBtn}
           url={url}
           key={name}
+          {...attributes}
         >
           {name}
         </ButtonLink>
@@ -62,19 +63,20 @@ export default class MainMenu extends Component {
 
     const mainNavAccorcions =
       drawerMainNav &&
-      drawerMainNav.map(({ name, children }, i) => (
+      drawerMainNav.map(({ name, children, attributes }, i) => (
         <Accordion
           accordionTitle={name}
           listId={name}
           color={mainNavColors[i % 4]}
           accordionList={children}
           key={name}
+          {...attributes}
         />
       ));
 
     const socialNavItems =
       drawerSocialNav &&
-      drawerSocialNav.map(({ name, url, icon, title }) => {
+      drawerSocialNav.map(({ name, url, icon, title, attributes }) => {
         const linkClasses = cx({
           socialMenuLink: true,
           [icon]: true
@@ -82,7 +84,7 @@ export default class MainMenu extends Component {
 
         return (
           <li key={name}>
-            <a className={linkClasses} href={url} title={title}>
+            <a className={linkClasses} href={url} title={title} {...attributes}>
               <span className={styles.socialMenuIcon}>
                 <Icon
                   name={icon}

--- a/src/components/Organisms/organisms.story.js
+++ b/src/components/Organisms/organisms.story.js
@@ -416,17 +416,26 @@ const menus = {
     },
     {
       name: 'Donate Now',
-      url: '#'
+      url: '#',
+      attributes: {
+        referrerpolicy: 'no-referrer-when-downgrade'
+      }
     }
   ],
   drawerMainNav: [
     {
       name: 'Group 1',
       url: '#',
+      attributes: {
+        title: 'Click to expand'
+      },
       children: [
         {
           name: 'Live Stream',
-          url: '#'
+          url: '#',
+          attributes: {
+            referrerpolicy: 'no-referrer-when-downgrade'
+          }
         },
         {
           name: 'Podcasts by Program',
@@ -444,7 +453,10 @@ const menus = {
       children: [
         {
           name: 'Live Stream',
-          url: '#'
+          url: '#',
+          attributes: {
+            referrerpolicy: 'no-referrer-when-downgrade'
+          }
         },
         {
           name: 'Podcasts by Program',
@@ -474,7 +486,10 @@ const menus = {
       children: [
         {
           name: 'Live Stream',
-          url: '#'
+          url: '#',
+          attributes: {
+            referrerpolicy: 'no-referrer-when-downgrade'
+          }
         },
         {
           name: 'Podcasts by Program',
@@ -492,7 +507,10 @@ const menus = {
       children: [
         {
           name: 'Live Stream',
-          url: '#'
+          url: '#',
+          attributes: {
+            referrerpolicy: 'no-referrer-when-downgrade'
+          }
         },
         {
           name: 'Podcasts by Program',
@@ -510,7 +528,10 @@ const menus = {
       name: 'Facebook',
       url: '#',
       icon: 'facebook',
-      title: 'Follow us on Facebook'
+      title: 'Follow us on Facebook',
+      attributes: {
+        referrerpolicy: 'no-referrer-when-downgrade'
+      }
     },
     {
       name: 'Twitter',
@@ -542,7 +563,10 @@ const menus = {
       name: 'Donate',
       url: '#',
       icon: 'heart',
-      color: 'Orange'
+      color: 'Orange',
+      attributes: {
+        referrerpolicy: 'no-referrer-when-downgrade'
+      }
     }
   ]
 };
@@ -571,7 +595,13 @@ storiesOf('Organisms/Footer', module)
       links={[
         { name: 'About PRI', url: '#' },
         { name: 'Contact Us', url: '#' },
-        { name: 'Donate', url: '#' },
+        {
+          name: 'Donate',
+          url: '#',
+          attributes: {
+            referrerpolicy: 'no-referrer-when-downgrade'
+          }
+        },
         { name: 'Meet the PRI.org Team', url: '#' },
         { name: 'Privacy policy', url: '#' },
         { name: 'Terms of use', url: '#' }

--- a/src/components/Pages/Home/__snapshots__/Home.test.js.snap
+++ b/src/components/Pages/Home/__snapshots__/Home.test.js.snap
@@ -1322,7 +1322,7 @@ exports[`<Home /> Matches the Header snapshot 1`] = `
       </div>
       <p>
         © 
-        2020
+        2021
          The World from PRX
       </p>
       <p>


### PR DESCRIPTION
Closes #148 

**This PR does the following:**
- Adds additional attributes from menu data to links

### To Review:

- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Review organism components with menus (Header, MainMenu, Footer).
- [x] Ensure _Donate_ and first item in accordions have `referrrerpolicy` attributes.
